### PR TITLE
doc: use fixedbootstrap theme from probably 

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -174,6 +174,8 @@ html_theme_options = {
     'bootstrap_version': "3",
 }
 
+html_sidebars = {'**': ['localtoc.html']}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -101,9 +101,9 @@ add_module_names = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'bootstrap'
+html_theme = 'fixedbootstrap'
 
-html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
+html_theme_path = ["themes"] + sphinx_bootstrap_theme.get_html_theme_path()
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -12,7 +12,7 @@ Before installing stormpy, make sure
 - `Storm <http://www.stormchecker.org/>`_ is available on your system.
 
 To avoid issues, we suggest that both pycarl and Storm use the same version of `carl <https://smtrat.github.io/carl>`_.
-The simplest way of ensuring this is to first install carl as explained in the `Storm installation guide <http://www.stormchecker.org/documentation/installation/manual-configuration.html#carl>`_.
+The simplest way of ensuring this is to first install carl as explained in the `Storm installation guide <https://www.stormchecker.org/documentation/obtain-storm/dependencies.html#carl>`_.
 You can then install Storm and pycarl independently.
 
 .. _compatibility_stormpy_storm:

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -74,11 +74,11 @@ or for the latest release use (remember to use the correct version)::
 **Build** stormpy in develop mode using your favourite python distribution way of installing: e.g.::
 
 	$ python3 setup.py develop
-	
+
 or::
 
 	$ pip install -ve .
-	
+
 
 Optional build arguments
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -127,3 +127,17 @@ or by invoking pytest directly with::
 
 If the tests pass, you can now use stormpy.
 To get started, continue with our :doc:`getting_started`, consult the test files in ``tests/`` or the :doc:`api` (work in progress).
+
+Building stormpy documentation
+------------------------------
+
+To build this documentation, you need additional dependencies::
+
+	$ pip install sphinx sphinx_bootstrap_theme nbsphinx ipykernel numpy
+
+as well as `pandoc <https://pandoc.org/>`_.
+
+Then build the documentation::
+
+	$ cd doc
+	$ make html

--- a/doc/source/themes/fixedbootstrap/layout.html
+++ b/doc/source/themes/fixedbootstrap/layout.html
@@ -1,0 +1,71 @@
+{% extends "bootstrap/layout.html" %}
+{% block extrahead %}
+    {{ super() }}
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,400;0,700;1,400&family=Source+Sans+Pro:ital,wght@0,300;0,400;1,400&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 15px/1.4 "Source Sans Pro",sans-serif;
+        }
+        h1, h2, h3, h5, h6, h6 {
+            font-family: "Source Sans Pro",sans-serif;
+        }
+        p {
+            font-family: "Source Serif Pro",serif;
+        }
+        .py, .field-list p, pre, code {
+            font-family: 'Source Code Pro', monospace;
+        }
+
+        /* fix navbar overlaying contents when clicking on anchors */
+        :target::before {
+            content: "";
+            display: block;
+            height: 60px; /* fixed header height*/
+            margin: -60px 0 0; /* negative fixed header height */
+            background: none;
+        }
+
+        /* hack to limit the yellow highlight to the the children of the target,
+           because of the above hack the target's highlight would be way too large */
+        dt:target {
+            background-color: transparent;
+        }
+        dt:target > * {
+            background-color: #fbe54e;
+        }
+
+        /* spacing adjustments */
+        .section {
+            margin-bottom: 10rem;
+            margin-top: 6rem;
+        }
+        div.body > .section:first-of-type {
+            margin-top: 0rem;
+        }
+        .class, .function, .data {
+            margin-top: 5rem;
+            margin-bottom: 7rem;
+            border-left: 1px solid #eee;
+            padding-left: 1rem;
+        }
+        dl.attribute > dd, dl.class > dd, dl.function > dd, dl.method > dd {
+            margin-left: 30px;
+        }
+        p {
+            margin-top: 1.05em;
+            margin-bottom: 1.05em;
+            text-align: justify;
+        }
+        .field-list p, li p {
+            text-align: left;
+        }
+        /* adjust font sizes */
+        dl.field-list, dl.attribute {
+            font-size: 90%;
+        }
+        .math {
+            font-size: 90.09%;
+        }
+    </style>
+{% endblock %}

--- a/doc/source/themes/fixedbootstrap/layout.html
+++ b/doc/source/themes/fixedbootstrap/layout.html
@@ -1,22 +1,7 @@
 {% extends "bootstrap/layout.html" %}
 {% block extrahead %}
     {{ super() }}
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,400;0,700;1,400&family=Source+Sans+Pro:ital,wght@0,300;0,400;1,400&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <style>
-        body {
-            font-family: 15px/1.4 "Source Sans Pro",sans-serif;
-        }
-        h1, h2, h3, h5, h6, h6 {
-            font-family: "Source Sans Pro",sans-serif;
-        }
-        .body p {
-            font-family: "Source Serif Pro",serif;
-        }
-        .py, .field-list p, pre, code {
-            font-family: 'Source Code Pro', monospace;
-        }
-
         .navbar p {
             padding: 0px 5px;
         }

--- a/doc/source/themes/fixedbootstrap/layout.html
+++ b/doc/source/themes/fixedbootstrap/layout.html
@@ -10,11 +10,15 @@
         h1, h2, h3, h5, h6, h6 {
             font-family: "Source Sans Pro",sans-serif;
         }
-        p {
+        .body p {
             font-family: "Source Serif Pro",serif;
         }
         .py, .field-list p, pre, code {
             font-family: 'Source Code Pro', monospace;
+        }
+
+        .navbar p {
+            padding: 0px 5px;
         }
 
         /* fix navbar overlaying contents when clicking on anchors */

--- a/doc/source/themes/fixedbootstrap/simpletoctree.html
+++ b/doc/source/themes/fixedbootstrap/simpletoctree.html
@@ -1,0 +1,3 @@
+{# Bootstrap theme overwrites globaltoc, but to use it in the sidebar we need the simple version below #}
+<h4 style="padding: 5px 20px">Contents</h4>
+{{ toctree() }}

--- a/doc/source/themes/fixedbootstrap/simpletoctree.html
+++ b/doc/source/themes/fixedbootstrap/simpletoctree.html
@@ -1,3 +1,0 @@
-{# Bootstrap theme overwrites globaltoc, but to use it in the sidebar we need the simple version below #}
-<h4 style="padding: 5px 20px">Contents</h4>
-{{ toctree() }}

--- a/doc/source/themes/fixedbootstrap/theme.conf
+++ b/doc/source/themes/fixedbootstrap/theme.conf
@@ -1,0 +1,4 @@
+# This theme inherits from the sphinx-bootstrap theme, but includes small CSS fixes
+# so the spacing in the generated documentation is a bit cleaner.
+[theme]
+inherit = bootstrap


### PR DESCRIPTION
The bootstrap theme for sphinx has some issues that I fixed in the ["probably" library](https://github.com/Philipp15b/probably) with a custom theme that inherits from it. When/if the offical bootstrap theme is fixed, the changes can be reversed easily.
For now, these changes make the API documentation readable with added spacing and highlights.

I fixed a link to the storm documentation and added documentation on how to build the documentation itself.
I also added a sidebar.

## Screenshots
![image](https://user-images.githubusercontent.com/425358/122416396-fe119880-cf88-11eb-8f1a-9b84aba40f11.png)

![image](https://user-images.githubusercontent.com/425358/122416412-023db600-cf89-11eb-9274-bb34a7e2d1a2.png)

![image](https://user-images.githubusercontent.com/425358/122416459-09fd5a80-cf89-11eb-99a6-8cecea91698f.png)

