### PR TITLE
Adaption to changes in Storm

### DIFF
--- a/src/storage/jani.cpp
+++ b/src/storage/jani.cpp
@@ -135,7 +135,6 @@ void define_jani(py::module& m) {
             return py::make_iterator(v.begin(), v.end());
         }, py::keep_alive<0, 1>())
         .def("add_variable", [](VariableSet& vs, Variable& v) -> void { vs.addVariable(v); })
-        .def("add_bounded_integer_variable", [](VariableSet& vs, BoundedIntegerVariable& v) -> auto& { return vs.addVariable(v); /*return vs.getVariable(v.getExpressionVariable());*/ }, py::return_value_policy::reference_internal, "variable"_a)
         .def("empty", &VariableSet::empty, "is there a variable in the set?")
         .def("get_variable_by_name", [](VariableSet& v, std::string const& name) -> auto& { return v.getVariable(name);})
         .def("get_variable_by_expr_variable", [](VariableSet& v, storm::expressions::Variable const& var) -> auto& { return v.getVariable(var);})
@@ -146,15 +145,6 @@ void define_jani(py::module& m) {
     variable.def_property_readonly("name", &Variable::getName, "name of constant")
             .def_property_readonly("expression_variable", &Variable::getExpressionVariable, "expression variable for this variable")
             .def_property_readonly("init_expression", &Variable::getInitExpression);
-
-    py::class_<BoundedIntegerVariable, std::shared_ptr<BoundedIntegerVariable>> bivariable(m, "JaniBoundedIntegerVariable", "A Bounded Integer", variable);
-    bivariable.def(py::init<std::string, storm::expressions::Variable, storm::expressions::Expression, storm::expressions::Expression, storm::expressions::Expression>(),
-                "name"_a, "expression_variable"_a, "init_value"_a, "lower_bound"_a, "upper_bound"_a)
-            .def(py::init<std::string, storm::expressions::Variable, storm::expressions::Expression, storm::expressions::Expression>(),
-                 "name"_a, "expression_variable"_a, "lower_bound"_a, "upper_bound"_a)
-            .def_property_readonly("lower_bound", &BoundedIntegerVariable::getLowerBound)
-            .def_property_readonly("upper_bound", &BoundedIntegerVariable::getUpperBound)
-    ;
 
     py::class_<Constant, std::shared_ptr<Constant>> constant(m, "JaniConstant", "A Constant in JANI");
     constant.def(py::init<std::string, storm::expressions::Variable>())

--- a/src/storage/jani.cpp
+++ b/src/storage/jani.cpp
@@ -1,6 +1,6 @@
 #include "jani.h"
 #include <storm/storage/jani/Model.h>
-#include <storm/storage/jani/JSONExporter.h>
+#include <storm/storage/jani/visitor/JSONExporter.h>
 #include <storm/storage/expressions/ExpressionManager.h>
 #include <storm/logic/RewardAccumulationEliminationVisitor.h>
 #include <storm/storage/jani/traverser/InformationCollector.h>


### PR DESCRIPTION
Adaption to changes for Jani.

The PR removes `BoundedIntegerVariable` for now as the data structure changed in Storm. A more general binding for all JANI variables could be added in the future.