### PR TITLE
Better handling of incompatibilities in Github Actions

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   GIT_URL: "${{ github.server_url }}/${{ github.repository }}.git"
-  BRANCH: "master"
+  BRANCH: "${{ github.ref_name }}"
   # github runners currently have two cores
   NR_JOBS: "2"
   CMAKE_DEBUG: "-DCMAKE_BUILD_TYPE=Debug"

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -40,7 +40,6 @@ jobs:
         debugOrRelease: ["debug", "release"]
 
     # Allow failures of stable versions as new features might have been added
-    continue-on-error: true
     steps:
       - name: Setup environment variables
         # this is strangely the best way to implement environment variables based on the value of another
@@ -78,9 +77,22 @@ jobs:
         run: |
           sudo docker exec storm bash -c "cd /opt; source venv/bin/activate; cd /opt/pycarl; python setup.py build_ext $DEBUG_SWITCH -j ${NR_JOBS} develop"
       - name: Build stormpy
+        id: build_stormpy
+        shell: bash {0} // Deactivate fast-fail to handle exit code for incompatibility
         run: |
           sudo docker exec storm bash -c "cd /opt; source venv/bin/activate; cd /opt/stormpy; python setup.py build_ext --storm-dir /opt/storm/build/ $DEBUG_SWITCH -j ${NR_JOBS} develop"
+          status=$?
+          if [ $status -eq 42 ]; then
+            # Warn about incompatibility but do not handle as failure
+            echo "::warning file=setup.py,line=82::Stormpy is incompatible with stable version of Storm"
+            # Deactivate tests
+            echo "::set-output name=run_tests::false"
+          else
+            echo "::set-output name=run_tests::true"
+            exit $status
+          fi
       - name: Run tests
+        if: steps.build_stormpy.outputs.run_tests == 'true'
         run: |
           # Install dependencies for tests
           # numpy is used in sphinx tests

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   GIT_URL: "${{ github.server_url }}/${{ github.repository }}.git"
-  BRANCH: "${{ github.ref_name }}"
+  BRANCH: "${{ github.ref }}"
   # github runners currently have two cores
   NR_JOBS: "2"
   CMAKE_DEBUG: "-DCMAKE_BUILD_TYPE=Debug"
@@ -62,7 +62,9 @@ jobs:
         run: sudo docker exec storm apt-get install -qq -y maven uuid-dev python python3 virtualenv
       - name: Git clone
         run: |
-          sudo docker exec storm git clone --depth 1 --branch $BRANCH $GIT_URL /opt/stormpy
+          # git clone cannot clone individual commits based on a sha and some other refs
+          # this workaround fixes this and fetches only one commit
+          sudo docker exec storm bash -c "mkdir /opt/stormpy; cd /opt/stormpy; git init && git remote add origin ${GIT_URL} && git fetch --depth 1 origin ${BRANCH} && git checkout FETCH_HEAD"
           sudo docker exec storm git clone --depth 1 --branch $CARL_PARSER_BRANCH $CARL_PARSER_GIT_URL /opt/carl-parser
           sudo docker exec storm git clone --depth 1 --branch $PYCARL_BRANCH $PYCARL_GIT_URL /opt/pycarl
       - name: Run cmake for carl-parser
@@ -137,7 +139,9 @@ jobs:
         run: sudo docker exec storm apt-get install -qq -y maven uuid-dev python python3 virtualenv
       - name: Git clone
         run: |
-          sudo docker exec storm git clone --depth 1 --branch $BRANCH $GIT_URL /opt/stormpy
+          # git clone cannot clone individual commits based on a sha and some other refs
+          # this workaround fixes this and fetches only one commit
+          sudo docker exec storm bash -c "mkdir /opt/stormpy; cd /opt/stormpy; git init && git remote add origin ${GIT_URL} && git fetch --depth 1 origin ${BRANCH} && git checkout FETCH_HEAD"
           sudo docker exec storm git clone --depth 1 --branch $CARL_PARSER_BRANCH $CARL_PARSER_GIT_URL /opt/carl-parser
           sudo docker exec storm git clone --depth 1 --branch $PYCARL_BRANCH $PYCARL_GIT_URL /opt/pycarl
       - name: Run cmake for carl-parser

--- a/setup.py
+++ b/setup.py
@@ -79,9 +79,9 @@ class CMakeBuild(build_ext):
         # Check version
         storm_version, storm_commit = setup_helper.parse_storm_version(cmake_conf.STORM_VERSION)
         if StrictVersion(storm_version) < StrictVersion(storm_min_version):
-            sys.exit(
-                'Stormpy - Error: Storm version {} from \'{}\' is not supported anymore!'.format(storm_version,
-                                                                                                 storm_dir))
+            print('Stormpy - Error: Storm version {} from \'{}\' is not supported anymore!'.format(storm_version, storm_dir))
+            print("                 For more information, see https://moves-rwth.github.io/stormpy/installation.html#compatibility-of-stormpy-and-storm")
+            sys.exit(42)  # Custom exit code which can be used for incompatible checks
 
         # Check additional support
         use_dft = cmake_conf.HAVE_STORM_DFT and not self.config.get_as_bool("disable_dft")


### PR DESCRIPTION
- `setup.py` returns exit code 42 if Storm/stormpy versions are incompatible
- Github Actions outputs a warning if versions are incompatible but does not fail