### PR TITLE
Github actions: explicitly install pytest

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -99,6 +99,7 @@ jobs:
           # Install dependencies for tests
           # numpy is used in sphinx tests
           sudo docker exec storm bash -c "cd /opt; source venv/bin/activate; pip install numpy"
+          sudo docker exec storm bash -c "cd /opt; source venv/bin/activate; pip install pytest"
           sudo docker exec storm bash -c "cd /opt; source venv/bin/activate; cd /opt/stormpy; python setup.py test"
 
   deploy:
@@ -163,6 +164,7 @@ jobs:
           # Install dependencies for tests
           # numpy is used in sphinx tests
           sudo docker exec storm bash -c "cd /opt; source venv/bin/activate; pip install numpy"
+          sudo docker exec storm bash -c "cd /opt; source venv/bin/activate; pip install pytest"
           sudo docker exec storm bash -c "cd /opt; source venv/bin/activate; cd /opt/stormpy; python setup.py test"
 
       - name: Deploy stormpy


### PR DESCRIPTION
There currently is an issue with the version bounds on the 3rd-party dependency `tomli`, see the [failed action](https://github.com/moves-rwth/stormpy/runs/4582826173?check_suite_focus=true). This issue was already [reported](https://github.com/psf/black/issues/2703) and a [fix](https://github.com/psf/black/pull/2718) should be available at some point.

For now, explicitly installing `pytest` during the Github actions prevents this issue.