### PR TITLE
Dft simulator

### DIFF
--- a/examples/dfts/02-dfts.py
+++ b/examples/dfts/02-dfts.py
@@ -1,0 +1,108 @@
+import stormpy
+import stormpy.dft
+
+import stormpy.examples
+import stormpy.examples.files
+
+
+def get_simulator(dft, seed=42):
+    # Compute all symmetries
+    symmetries = dft.symmetries()
+    # Set only top event as relevant
+    relevant_events = stormpy.dft.compute_relevant_events(dft, [])
+    dft.set_relevant_events(relevant_events, False)
+    # Create information for state space generation
+    info = dft.state_generation_info(symmetries)
+    # Initialize random generator
+    generator = stormpy.dft.RandomGenerator.create(seed)
+    # Create simulator
+    return stormpy.dft.DFTSimulator_double(dft, info, generator)
+
+
+def print_status(state, dft):
+    if state.invalid():
+        print("State is invalid because a SEQ is violated")
+        return
+    state_tle = state.failed(dft.top_level_element.id)
+    print("DFT is {}".format("Failed" if state_tle else "Operational"))
+    for i in range(dft.nr_elements()):
+        # Order of checks is important!
+        if state.operational(i):
+            status = "Operational"
+        elif state.dontcare(i):
+            status = "Don't Care"
+        elif state.failsafe(i):
+            status = "FailSafe"
+        elif state.failed(i):
+            status = "Failed"
+        else:
+            status = "Unknown"
+        elem = dft.get_element(i)
+        if elem.type == stormpy.dft.DFTElementType.SPARE:
+            cur_used = state.spare_uses(i)
+            if cur_used == i:
+                status += ", not using anything"
+            else:
+                elem_used = dft.get_element(cur_used)
+                status += ", currently using {}".format(elem_used.name)
+        print("\t{}: {}".format(elem.name, status))
+
+
+def get_failables(state, dft):
+    failables = dict()
+    for f in state.failable():
+        fail_be = f.get_fail_be_double(dft)
+        failables[fail_be[0].name] = f
+    return failables
+
+
+def analyze_via_simulation(simulator, timebound, no_simulations=1000):
+    success = 0
+    for i in range(no_simulations):
+        res = simulator.simulate_trace(timebound)
+        if res == stormpy.dft.SimulationResult.SUCCESSFUL:
+            success += 1
+    return success / no_simulations
+
+
+def example_dft_simulator_02():
+    # Load DFT from Galileo
+    path = stormpy.examples.files.dft_galileo_hecs
+    dft = stormpy.dft.load_dft_galileo_file(path)
+    print("DFT with {} elements, {} BEs and {} dynamic elements.".format(dft.nr_elements(), dft.nr_be(),
+                                                                         dft.nr_dynamic()))
+
+    # Create simulator
+    simulator = get_simulator(dft, seed=42)
+
+    # Get initial state
+    state = simulator.current()
+    print_status(state, dft)
+
+    choices = ["n15", "n118", "n134", "n23", "n7"]
+    terminate = False
+
+    i = 0
+    while not terminate:
+        failables = get_failables(state, dft)
+        print("Failable BEs: {}".format(", ".join(failables.keys())))
+        chosen = choices[i]
+        i += 1
+        assert chosen in failables
+        print("Let {} fail".format(chosen))
+        res = simulator.step(failables[chosen])
+        print("Simulation was {}".format(res))
+        state = simulator.current()
+        print_status(state, dft)
+        terminate = i >= len(choices)
+
+    # Analyze DFT via simulation
+    timebound = 5
+    no_runs = 1000
+    print("Perform {} simulation runs for timebound {}".format(no_runs, timebound))
+    result = analyze_via_simulation(simulator, timebound, no_simulations=no_runs)
+    print("Result for time bound {}: {}".format(timebound, result))
+
+
+if __name__ == '__main__':
+    example_dft_simulator_02()

--- a/src/dft/dft.cpp
+++ b/src/dft/dft.cpp
@@ -38,6 +38,8 @@ void define_dft(py::module& m) {
         .def("symmetries", [](DFT<double>& dft) {
                 return dft.findSymmetries(dft.colourDFT());
             }, "Compute symmetries in DFT")
+        .def("state_generation_info", &DFT<double>::buildStateGenerationInfo, py::arg("symmetries"), "Build state generation information")
+        .def("set_relevant_events", &DFT<double>::setRelevantEvents, py::arg("relevant_events"), py::arg("allow_dc_for_revelant"))
     ;
 
     py::class_<DFT<storm::RationalFunction>, std::shared_ptr<DFT<storm::RationalFunction>>>(m, "ParametricDFT", "Parametric DFT")
@@ -57,6 +59,8 @@ void define_dft(py::module& m) {
         .def("symmetries", [](DFT<storm::RationalFunction>& dft) {
                 return dft.findSymmetries(dft.colourDFT());
             }, "Compute symmetries in DFT")
+        .def("state_generation_info", &DFT<storm::RationalFunction>::buildStateGenerationInfo, py::arg("symmetries"))
+        .def("set_relevant_events", &DFT<storm::RationalFunction>::setRelevantEvents, py::arg("relevant_events"), py::arg("allow_dc_for_revelant"))
     ;
 
 }

--- a/src/dft/dft.cpp
+++ b/src/dft/dft.cpp
@@ -19,18 +19,6 @@ void define_dft(py::module& m) {
             storm::settings::addModule<storm::settings::modules::DftIOSettings>();
         }, "Initialize Storm-dft");
 
-    // DFT element
-    py::class_<DFTElement<double>, std::shared_ptr<DFTElement<double>>>(m, "DFTElement", "DFT element")
-        .def_property_readonly("id", &DFTElement<double>::id, "Id")
-        .def_property_readonly("name", &DFTElement<double>::name, "Name")
-        .def("__str__", &DFTElement<double>::toString)
-    ;
-
-    py::class_<DFTElement<storm::RationalFunction>, std::shared_ptr<DFTElement<storm::RationalFunction>>>(m, "ParametricDFTElement", "Parametric DFT element")
-        .def_property_readonly("id", &DFTElement<storm::RationalFunction>::id, "Id")
-        .def_property_readonly("name", &DFTElement<storm::RationalFunction>::name, "Name")
-        .def("__str__", &DFTElement<storm::RationalFunction>::toString)
-    ;
 
     // DFT class
     py::class_<DFT<double>, std::shared_ptr<DFT<double>>>(m, "DFT", "Dynamic Fault Tree")

--- a/src/dft/dft_elements.cpp
+++ b/src/dft/dft_elements.cpp
@@ -8,13 +8,31 @@ template<typename ValueType> using BE = storm::storage::DFTBE<ValueType>;
 template<typename ValueType> using Dependency = storm::storage::DFTDependency<ValueType>;
 
 
+void define_dft_elements(py::module& m) {
+
+    // DFT element type
+    py::enum_<storm::storage::DFTElementType>(m, "DFTElementType")
+        .value("BE", storm::storage::DFTElementType::BE)
+        .value("AND", storm::storage::DFTElementType::AND)
+        .value("OR", storm::storage::DFTElementType::OR)
+        .value("VOT", storm::storage::DFTElementType::VOT)
+        .value("PAND", storm::storage::DFTElementType::PAND)
+        .value("POR", storm::storage::DFTElementType::POR)
+        .value("SPARE", storm::storage::DFTElementType::SPARE)
+        .value("PDEP", storm::storage::DFTElementType::PDEP)
+        .value("SEQ", storm::storage::DFTElementType::SEQ)
+        .value("MUTEX", storm::storage::DFTElementType::MUTEX)
+    ;
+}
+
 template<typename ValueType>
-void define_dft_elements(py::module& m, std::string const& vt_suffix) {
+void define_dft_elements_typed(py::module& m, std::string const& vt_suffix) {
 
     // DFT elements
     py::class_<DFTElement<ValueType>, std::shared_ptr<DFTElement<ValueType>>> element(m, ("DFTElement"+vt_suffix).c_str(), "DFT element");
     element.def_property_readonly("id", &DFTElement<ValueType>::id, "Id")
         .def_property_readonly("name", &DFTElement<ValueType>::name, "Name")
+        .def_property_readonly("type", &DFTElement<ValueType>::type, "Type")
         .def("__str__", &DFTElement<ValueType>::toString)
     ;
 
@@ -29,5 +47,5 @@ void define_dft_elements(py::module& m, std::string const& vt_suffix) {
 }
 
 
-template void define_dft_elements<double>(py::module& m, std::string const& vt_suffix);
-template void define_dft_elements<storm::RationalFunction>(py::module& m, std::string const& vt_suffix);
+template void define_dft_elements_typed<double>(py::module& m, std::string const& vt_suffix);
+template void define_dft_elements_typed<storm::RationalFunction>(py::module& m, std::string const& vt_suffix);

--- a/src/dft/dft_elements.cpp
+++ b/src/dft/dft_elements.cpp
@@ -1,0 +1,33 @@
+#include "dft_elements.h"
+#include "src/helpers.h"
+#include "storm-dft/storage/dft/DFTElements.h"
+
+
+template<typename ValueType> using DFTElement = storm::storage::DFTElement<ValueType>;
+template<typename ValueType> using BE = storm::storage::DFTBE<ValueType>;
+template<typename ValueType> using Dependency = storm::storage::DFTDependency<ValueType>;
+
+
+template<typename ValueType>
+void define_dft_elements(py::module& m, std::string const& vt_suffix) {
+
+    // DFT elements
+    py::class_<DFTElement<ValueType>, std::shared_ptr<DFTElement<ValueType>>> element(m, ("DFTElement"+vt_suffix).c_str(), "DFT element");
+    element.def_property_readonly("id", &DFTElement<ValueType>::id, "Id")
+        .def_property_readonly("name", &DFTElement<ValueType>::name, "Name")
+        .def("__str__", &DFTElement<ValueType>::toString)
+    ;
+
+    py::class_<BE<ValueType>, std::shared_ptr<BE<ValueType>>>(m, ("DFTBE"+vt_suffix).c_str(), "Basic Event", element)
+        .def("__str__", &BE<ValueType>::toString)
+    ;
+
+    py::class_<Dependency<ValueType>, std::shared_ptr<Dependency<ValueType>>>(m, ("DFTDependency"+vt_suffix).c_str(), "Dependency", element)
+        .def("__str__", &Dependency<ValueType>::toString)
+    ;
+
+}
+
+
+template void define_dft_elements<double>(py::module& m, std::string const& vt_suffix);
+template void define_dft_elements<storm::RationalFunction>(py::module& m, std::string const& vt_suffix);

--- a/src/dft/dft_elements.h
+++ b/src/dft/dft_elements.h
@@ -2,5 +2,7 @@
 
 #include "common.h"
 
+void define_dft_elements(py::module& m);
+
 template<typename ValueType>
-void define_dft_elements(py::module& m, std::string const& vt_suffix);
+void define_dft_elements_typed(py::module& m, std::string const& vt_suffix);

--- a/src/dft/dft_elements.h
+++ b/src/dft/dft_elements.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "common.h"
+
+template<typename ValueType>
+void define_dft_elements(py::module& m, std::string const& vt_suffix);

--- a/src/dft/dft_state.cpp
+++ b/src/dft/dft_state.cpp
@@ -13,6 +13,7 @@ void define_dft_state(py::module& m, std::string const& vt_suffix) {
 
     // DFT state
     py::class_<DFTState<ValueType>, std::shared_ptr<DFTState<ValueType>>>(m, ("DFTState"+vt_suffix).c_str(), "DFT state")
+        .def("operational", &DFTState<ValueType>::isOperational, "Is element operational", py::arg("id"))
         .def("failed", [](DFTState<ValueType> const& state, size_t id) {
                 return state.hasFailed(id);
             }, "Is element failed", py::arg("id"))
@@ -22,6 +23,7 @@ void define_dft_state(py::module& m, std::string const& vt_suffix) {
         .def("dontcare", &DFTState<ValueType>::dontCare, "Is element Don't Care", py::arg("id"))
         .def("invalid", &DFTState<ValueType>::isInvalid, "Is state invalid")
         .def("failable", &DFTState<ValueType>::getFailableElements, "Get failable elements")
+        .def("spare_uses", &DFTState<ValueType>::uses, "Child currently used by a SPARE", py::arg("spare_id"))
         .def("__str__", [](DFTState<ValueType> const& state) {
                 return streamToString<storm::storage::BitVector>(state.status());
             })

--- a/src/dft/dft_state.cpp
+++ b/src/dft/dft_state.cpp
@@ -39,11 +39,13 @@ void define_failable_elements(py::module& m) {
         FailableIterator(Failable const &failable, py::object ref) : failable(failable), ref(ref) { }
 
         FailableIter next() {
-            ++it;
-            if (it == failable.end())
+            if (it == failable.end()) {
                 throw py::stop_iteration();
-            else
-                return it;
+            } else {
+                FailableIter res(it);
+                ++it;
+                return res;
+            }
         }
 
         Failable const&failable;

--- a/src/dft/dft_state.cpp
+++ b/src/dft/dft_state.cpp
@@ -1,0 +1,74 @@
+#include "dft_state.h"
+#include "src/helpers.h"
+#include "storm-dft/storage/dft/DFTState.h"
+#include "storm-dft/storage/dft/FailableElements.h"
+
+
+template<typename ValueType> using DFTState = storm::storage::DFTState<ValueType>;
+typedef storm::dft::storage::FailableElements Failable;
+typedef storm::dft::storage::FailableElements::const_iterator FailableIter;
+
+template<typename ValueType>
+void define_dft_state(py::module& m, std::string const& vt_suffix) {
+
+    // DFT state
+    py::class_<DFTState<ValueType>, std::shared_ptr<DFTState<ValueType>>>(m, ("DFTState"+vt_suffix).c_str(), "DFT state")
+        .def("failed", [](DFTState<ValueType> const& state, size_t id) {
+                return state.hasFailed(id);
+            }, "Is element failed", py::arg("id"))
+        .def("failsafe", [](DFTState<ValueType> const& state, size_t id) {
+                return state.isFailsafe(id);
+            }, "Is element fail-safe", py::arg("id"))
+        .def("dontcare", &DFTState<ValueType>::dontCare, "Is element Don't Care", py::arg("id"))
+        .def("invalid", &DFTState<ValueType>::isInvalid, "Is state invalid")
+        .def("failable", &DFTState<ValueType>::getFailableElements, "Get failable elements")
+        .def("__str__", [](DFTState<ValueType> const& state) {
+                return streamToString<storm::storage::BitVector>(state.status());
+            })
+        .def("to_string", [](std::shared_ptr<DFTState<ValueType>> const& state, storm::storage::DFT<ValueType> const& dft) {
+                return dft.getStateString(state);
+            }, "Print status", py::arg("dft"))
+    ;
+}
+
+
+void define_failable_elements(py::module& m) {
+
+    // Helper iterator for access from python
+    struct FailableIterator {
+        FailableIterator(Failable const &failable, py::object ref) : failable(failable), ref(ref) { }
+
+        FailableIter next() {
+            ++it;
+            if (it == failable.end())
+                throw py::stop_iteration();
+            else
+                return it;
+        }
+
+        Failable const&failable;
+        py::object ref; // keep a reference
+        FailableIter it = failable.begin();
+    };
+
+
+    py::class_<Failable, std::shared_ptr<Failable>>(m, "FailableElements", "Failable elements in DFT state")
+        .def("__iter__", [](py::object s) { return FailableIterator(s.cast<Failable const&>(), s); })
+    ;
+
+    py::class_<FailableIterator>(m, "FailableIterator")
+        .def("__iter__", [](FailableIterator &it) -> FailableIterator& { return it; })
+        .def("__next__", &FailableIterator::next)
+    ;
+
+    py::class_<FailableIter, std::shared_ptr<FailableIter>>(m, "FailableElement", "Failable element")
+        .def("due_dependency", &FailableIter::isFailureDueToDependency, "Is failure due to dependency")
+        .def("get_fail_be_double", &FailableIter::getFailBE<double>, py::arg("dft"), "Get BE which fails")
+        .def("get_fail_be_ratfunc", &FailableIter::getFailBE<storm::RationalFunction>, py::arg("dft"), "Get BE which fails")
+    ;
+
+}
+
+
+template void define_dft_state<double>(py::module& m, std::string const& vt_suffix);
+template void define_dft_state<storm::RationalFunction>(py::module& m, std::string const& vt_suffix);

--- a/src/dft/dft_state.h
+++ b/src/dft/dft_state.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "common.h"
+
+template<typename ValueType>
+void define_dft_state(py::module& m, std::string const& vt_suffix);
+
+void define_failable_elements(py::module& m);

--- a/src/dft/simulator.cpp
+++ b/src/dft/simulator.cpp
@@ -39,7 +39,7 @@ void define_simulator_typed(py::module& m, std::string const& vt_suffix) {
     py::class_<Simulator<ValueType>, std::shared_ptr<Simulator<ValueType>>>(m, ("DFTSimulator"+vt_suffix).c_str(), "Simulator for DFT traces")
         .def("__init__", [](Simulator<ValueType> &instance, storm::storage::DFT<ValueType> const& dft, DFTStateInfo const& stateInfo, RandomGenerator & randomGenerator) -> void {
                 new (&instance) Simulator(dft, stateInfo, randomGenerator);
-            }, py::arg("dft"), py::arg("state_generation_info"), py::arg("generator"), "Create Simulator")
+            }, py::keep_alive<1, 3>(), py::arg("dft"), py::arg("state_generation_info"), py::arg("generator"), "Create Simulator")
         .def("reset", &Simulator<ValueType>::resetToInitial, "Reset to initial state")
         .def("current", &Simulator<ValueType>::getCurrentState, "Get current state")
         .def("step", &Simulator<ValueType>::step, py::arg("next_failure"), py::arg("dependency_success") = true, "Perform simulation step according to next_failure. For PDEPs, dependency_success determines whether the PDEP was successful or not.")

--- a/src/dft/simulator.cpp
+++ b/src/dft/simulator.cpp
@@ -1,0 +1,53 @@
+#include "simulator.h"
+#include "src/helpers.h"
+
+#include "storm-dft/simulator/DFTTraceSimulator.h"
+#include "storm-dft/api/storm-dft.h"
+#include "storm-dft/generator/DftNextStateGenerator.h"
+#include "storm-dft/storage/dft/SymmetricUnits.h"
+#include "storm-dft/storage/dft/DFTIsomorphism.h"
+
+
+template<typename ValueType> using Simulator = storm::dft::simulator::DFTTraceSimulator<ValueType>;
+typedef storm::storage::DFTStateGenerationInfo DFTStateInfo;
+typedef boost::mt19937 RandomGenerator;
+
+
+void define_simulator(py::module& m) {
+
+    // Simulation result
+    py::enum_<storm::dft::simulator::SimulationResult>(m, "SimulationResult")
+        .value("SUCCESSFUL", storm::dft::simulator::SimulationResult::SUCCESSFUL)
+        .value("UNSUCCESSFUL", storm::dft::simulator::SimulationResult::UNSUCCESSFUL)
+        .value("INVAlID", storm::dft::simulator::SimulationResult::INVALID)
+    ;
+    py::class_<DFTStateInfo, std::shared_ptr<DFTStateInfo>>(m, "DFTStateInfo", "State Generation Info for DFT")
+    ;
+
+    py::class_<RandomGenerator, std::shared_ptr<RandomGenerator>>(m, "RandomGenerator", "Random number generator")
+        .def_static("create", [](unsigned int seed) -> RandomGenerator {
+            return RandomGenerator(seed);
+        }, py::arg("seed"), "Initialize random number generator")
+    ;
+}
+
+
+template<typename ValueType>
+void define_simulator_typed(py::module& m, std::string const& vt_suffix) {
+
+    // Simulator for DFTs
+    py::class_<Simulator<ValueType>, std::shared_ptr<Simulator<ValueType>>>(m, ("DFTSimulator"+vt_suffix).c_str(), "Simulator for DFT traces")
+        .def("__init__", [](Simulator<ValueType> &instance, storm::storage::DFT<ValueType> const& dft, DFTStateInfo const& stateInfo, RandomGenerator & randomGenerator) -> void {
+                new (&instance) Simulator(dft, stateInfo, randomGenerator);
+            }, py::arg("dft"), py::arg("state_generation_info"), py::arg("generator"), "Create Simulator")
+        .def("reset", &Simulator<ValueType>::resetToInitial, "Reset to initial state")
+        .def("current", &Simulator<ValueType>::getCurrentState, "Get current state")
+        .def("step", &Simulator<ValueType>::step, py::arg("next_failure"), py::arg("dependency_success") = true, "Perform simulation step according to next_failure. For PDEPs, dependency_success determines whether the PDEP was successful or not.")
+        .def("random_step", &Simulator<ValueType>::randomStep, "Perform random simulation step. Returns a tuple of the simulation result and the time which progressed during this step.")
+        .def("simulate_trace", &Simulator<ValueType>::simulateCompleteTrace, py::arg("timebound"), "Simulate complete trace for given timebound")
+    ;
+}
+
+
+template void define_simulator_typed<double>(py::module& m, std::string const& vt_suffix);
+template void define_simulator_typed<storm::RationalFunction>(py::module& m, std::string const& vt_suffix);

--- a/src/dft/simulator.cpp
+++ b/src/dft/simulator.cpp
@@ -39,7 +39,7 @@ void define_simulator_typed(py::module& m, std::string const& vt_suffix) {
     py::class_<Simulator<ValueType>, std::shared_ptr<Simulator<ValueType>>>(m, ("DFTSimulator"+vt_suffix).c_str(), "Simulator for DFT traces")
         .def("__init__", [](Simulator<ValueType> &instance, storm::storage::DFT<ValueType> const& dft, DFTStateInfo const& stateInfo, RandomGenerator & randomGenerator) -> void {
                 new (&instance) Simulator(dft, stateInfo, randomGenerator);
-            }, py::keep_alive<1, 3>(), py::arg("dft"), py::arg("state_generation_info"), py::arg("generator"), "Create Simulator")
+            }, py::keep_alive<1,2>(), py::keep_alive<1, 3>(), py::keep_alive<1,4>(), py::arg("dft"), py::arg("state_generation_info"), py::arg("generator"), "Create Simulator")
         .def("reset", &Simulator<ValueType>::resetToInitial, "Reset to initial state")
         .def("current", &Simulator<ValueType>::getCurrentState, "Get current state")
         .def("step", &Simulator<ValueType>::step, py::arg("next_failure"), py::arg("dependency_success") = true, "Perform simulation step according to next_failure. For PDEPs, dependency_success determines whether the PDEP was successful or not.")

--- a/src/dft/simulator.h
+++ b/src/dft/simulator.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "common.h"
+
+void define_simulator(py::module& m);
+
+template<typename ValueType>
+void define_simulator_typed(py::module& m, std::string const& vt_suffix);

--- a/src/mod_dft.cpp
+++ b/src/mod_dft.cpp
@@ -1,6 +1,8 @@
 #include "common.h"
 
 #include "dft/dft.h"
+#include "dft/dft_elements.h"
+#include "dft/dft_state.h"
 #include "dft/io.h"
 #include "dft/analysis.h"
 
@@ -13,6 +15,11 @@ PYBIND11_MODULE(dft, m) {
 #endif
 
     define_dft(m);
+    define_dft_elements<double>(m, "_double");
+    define_dft_elements<storm::RationalFunction>(m, "_ratfunc");
+    define_dft_state<double>(m, "_double");
+    define_dft_state<storm::RationalFunction>(m, "_ratfunc");
+    define_failable_elements(m);
     define_symmetries(m);
     define_input(m);
     define_output(m);

--- a/src/mod_dft.cpp
+++ b/src/mod_dft.cpp
@@ -5,6 +5,7 @@
 #include "dft/dft_state.h"
 #include "dft/io.h"
 #include "dft/analysis.h"
+#include "dft/simulator.h"
 
 PYBIND11_MODULE(dft, m) {
     m.doc() = "Functionality for DFT analysis";
@@ -24,4 +25,7 @@ PYBIND11_MODULE(dft, m) {
     define_input(m);
     define_output(m);
     define_analysis(m);
+    define_simulator(m);
+    define_simulator_typed<double>(m, "_double");
+    define_simulator_typed<storm::RationalFunction>(m, "_ratfunc");
 }

--- a/src/mod_dft.cpp
+++ b/src/mod_dft.cpp
@@ -16,8 +16,9 @@ PYBIND11_MODULE(dft, m) {
 #endif
 
     define_dft(m);
-    define_dft_elements<double>(m, "_double");
-    define_dft_elements<storm::RationalFunction>(m, "_ratfunc");
+    define_dft_elements(m);
+    define_dft_elements_typed<double>(m, "_double");
+    define_dft_elements_typed<storm::RationalFunction>(m, "_ratfunc");
     define_dft_state<double>(m, "_double");
     define_dft_state<storm::RationalFunction>(m, "_ratfunc");
     define_failable_elements(m);

--- a/tests/dft/test_dft_simulator.py
+++ b/tests/dft/test_dft_simulator.py
@@ -59,8 +59,11 @@ class TestSimulator:
         c = dft.get_element_by_name("C").id
 
         state = simulator.current()
+        assert state.operational(a)
         assert not state.failed(a)
+        assert state.operational(b)
         assert not state.failed(b)
+        assert state.operational(c)
         assert not state.failed(c)
 
         # Let C fail
@@ -73,8 +76,11 @@ class TestSimulator:
         res = simulator.step(next_fail)
         assert res == stormpy.dft.SimulationResult.SUCCESSFUL
         state = simulator.current()
+        assert state.operational(a)
         assert not state.failed(a)
+        assert state.operational(b)
         assert not state.failed(b)
+        assert not state.operational(c)
         assert state.failed(c)
 
         # Let B fail
@@ -87,8 +93,11 @@ class TestSimulator:
         res = simulator.step(next_fail)
         assert res == stormpy.dft.SimulationResult.SUCCESSFUL
         state = simulator.current()
+        assert not state.operational(a)
         assert state.failed(a)
+        assert not state.operational(b)
         assert state.failed(b)
+        assert not state.operational(c)
         assert state.failed(c)
 
         failable = state.failable()

--- a/tests/dft/test_dft_simulator.py
+++ b/tests/dft/test_dft_simulator.py
@@ -1,0 +1,96 @@
+import stormpy
+from helpers.helper import get_example_path
+
+import math
+from configurations import dft
+
+
+@dft
+class TestSimulator:
+
+    def test_random_steps(self):
+        dft = stormpy.dft.load_dft_json_file(get_example_path("dft", "and.json"))
+        symmetries = dft.symmetries()
+        relevant_events = stormpy.dft.compute_relevant_events(dft, [])
+        dft.set_relevant_events(relevant_events, False)
+        info = dft.state_generation_info(symmetries)
+        generator = stormpy.dft.RandomGenerator.create(5)
+        simulator = stormpy.dft.DFTSimulator_double(dft, info, generator)
+        res, time = simulator.random_step()
+        assert res == stormpy.dft.SimulationResult.SUCCESSFUL
+        assert time > 0
+        res, time = simulator.random_step()
+        assert res == stormpy.dft.SimulationResult.SUCCESSFUL
+        assert time > 0
+        res, time = simulator.random_step()
+        assert res == stormpy.dft.SimulationResult.UNSUCCESSFUL
+        assert time <= 0
+        res, time = simulator.random_step()
+        assert res == stormpy.dft.SimulationResult.UNSUCCESSFUL
+        assert time <= 0
+
+    def test_simulate_trace(self):
+        dft = stormpy.dft.load_dft_json_file(get_example_path("dft", "and.json"))
+        symmetries = dft.symmetries()
+        relevant_events = stormpy.dft.compute_relevant_events(dft, [])
+        dft.set_relevant_events(relevant_events, False)
+        info = dft.state_generation_info(symmetries)
+        generator = stormpy.dft.RandomGenerator.create(5)
+        simulator = stormpy.dft.DFTSimulator_double(dft, info, generator)
+        res = simulator.simulate_trace(2)
+        assert res == stormpy.dft.SimulationResult.SUCCESSFUL
+        res = simulator.simulate_trace(2)
+        assert res == stormpy.dft.SimulationResult.UNSUCCESSFUL
+        res = simulator.simulate_trace(2)
+        assert res == stormpy.dft.SimulationResult.UNSUCCESSFUL
+
+    def test_steps(self):
+        dft = stormpy.dft.load_dft_json_file(get_example_path("dft", "and.json"))
+        symmetries = dft.symmetries()
+        relevant_events = stormpy.dft.compute_relevant_events(dft, [])
+        dft.set_relevant_events(relevant_events, False)
+        info = dft.state_generation_info(symmetries)
+        generator = stormpy.dft.RandomGenerator.create(5)
+        simulator = stormpy.dft.DFTSimulator_double(dft, info, generator)
+
+        failable_check = ["B", "C"]
+        a = dft.get_element_by_name("A").id
+        b = dft.get_element_by_name("B").id
+        c = dft.get_element_by_name("C").id
+
+        state = simulator.current()
+        assert not state.failed(a)
+        assert not state.failed(b)
+        assert not state.failed(c)
+
+        # Let C fail
+        failable = state.failable()
+        for f in failable:
+            fail_be = f.get_fail_be_double(dft)
+            assert fail_be[0].name in failable_check
+            if fail_be[0].name == "C":
+                next_fail = f
+        res = simulator.step(next_fail)
+        assert res == stormpy.dft.SimulationResult.SUCCESSFUL
+        state = simulator.current()
+        assert not state.failed(a)
+        assert not state.failed(b)
+        assert state.failed(c)
+
+        # Let B fail
+        state = simulator.current()
+        failable = state.failable()
+        for f in failable:
+            fail_be = f.get_fail_be_double(dft)
+            assert fail_be[0].name == "B"
+            next_fail = f
+        res = simulator.step(next_fail)
+        assert res == stormpy.dft.SimulationResult.SUCCESSFUL
+        state = simulator.current()
+        assert state.failed(a)
+        assert state.failed(b)
+        assert state.failed(c)
+
+        failable = state.failable()
+        for f in failable:
+            assert False # no failable elements


### PR DESCRIPTION
Support for simulating DFT:
- simulating complete traces via Monte Carlo simulation
- interactive simulation by manually specifying next failures

An example can be found in `examples/dfts/02-dfts.py`.
