### PR TITLE
Updated deprecated pybind constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 Version 1.6.x
 -------------
+### Version 1.6.?
+- Developer: Storm is built with C++17
+- Developer: updated pybind11 to version 2.8.1 and adapted bindings accordingly
+
 ### Version 1.6.4 (2022/01)
 Requires storm version >= 1.6.4 and pycarl version >= 2.0.5
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
 # This sets the default visibility from hidden to default,
 # which is recommended *not* to do, but leads to errors otherwise.
 set(CMAKE_CXX_VISIBILITY_PRESET "default")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/src/generated/config.h)
 

--- a/src/core/analysis.cpp
+++ b/src/core/analysis.cpp
@@ -7,9 +7,7 @@ void define_graph_constraints(py::module& m) {
 
     // ConstraintCollector
     py::class_<storm::analysis::ConstraintCollector<storm::RationalFunction>, std::shared_ptr<storm::analysis::ConstraintCollector<storm::RationalFunction>>>(m, "ConstraintCollector", "Collector for constraints on parametric Markov chains")
-            .def("__init__", [](storm::analysis::ConstraintCollector<storm::RationalFunction> &instance, storm::models::sparse::Model<storm::RationalFunction> const& model) -> void {
-                new (&instance) storm::analysis::ConstraintCollector<storm::RationalFunction>(model);
-            }, py::arg("model"))
+            .def(py::init<storm::models::sparse::Model<storm::RationalFunction> const&>(), py::arg("model"))
         .def_property_readonly("wellformed_constraints", &storm::analysis::ConstraintCollector<storm::RationalFunction>::getWellformedConstraints, "Get the constraints ensuring a wellformed model")
         .def_property_readonly("graph_preserving_constraints", &storm::analysis::ConstraintCollector<storm::RationalFunction>::getGraphPreservingConstraints, "Get the constraints ensuring the graph is preserved")
     ;

--- a/src/dft/simulator.cpp
+++ b/src/dft/simulator.cpp
@@ -37,9 +37,7 @@ void define_simulator_typed(py::module& m, std::string const& vt_suffix) {
 
     // Simulator for DFTs
     py::class_<Simulator<ValueType>, std::shared_ptr<Simulator<ValueType>>>(m, ("DFTSimulator"+vt_suffix).c_str(), "Simulator for DFT traces")
-        .def("__init__", [](Simulator<ValueType> &instance, storm::storage::DFT<ValueType> const& dft, DFTStateInfo const& stateInfo, RandomGenerator & randomGenerator) -> void {
-                new (&instance) Simulator<ValueType>(dft, stateInfo, randomGenerator);
-            }, py::keep_alive<1,2>(), py::keep_alive<1, 3>(), py::keep_alive<1,4>(), py::arg("dft"), py::arg("state_generation_info"), py::arg("generator"), "Create Simulator")
+        .def(py::init<storm::storage::DFT<ValueType> const&, DFTStateInfo const&, RandomGenerator&>(), py::keep_alive<1,2>(), py::keep_alive<1, 3>(), py::keep_alive<1,4>(), py::arg("dft"), py::arg("state_generation_info"), py::arg("generator"), "Create Simulator")
         .def("reset", &Simulator<ValueType>::resetToInitial, "Reset to initial state")
         .def("current", &Simulator<ValueType>::getCurrentState, "Get current state")
         .def("step", &Simulator<ValueType>::step, py::arg("next_failure"), py::arg("dependency_success") = true, "Perform simulation step according to next_failure. For PDEPs, dependency_success determines whether the PDEP was successful or not.")

--- a/src/pars/pars.cpp
+++ b/src/pars/pars.cpp
@@ -17,9 +17,7 @@ void define_pars(py::module& m) {
         }, "Initialize Storm-pars");
 
     py::class_<SparseParametricDtmcSimplifier, std::shared_ptr<SparseParametricDtmcSimplifier>>(m, "_SparseParametricDtmcSimplifier", "Model simplifier for parametric DTMCs")
-       .def("__init__", [](SparseParametricDtmcSimplifier &instance, Dtmc const& dtmc) -> void {
-                new (&instance) SparseParametricDtmcSimplifier(dtmc);
-            }, py::arg("dtmc"))
+       .def(py::init<Dtmc const&>(), py::arg("dtmc"))
        .def("simplify", [](SparseParametricDtmcSimplifier &simplifier, storm::logic::Formula const& formula) -> bool {
                 return simplifier.simplify(formula);
             }, "Simplify model", py::arg("formula"))
@@ -32,9 +30,7 @@ void define_pars(py::module& m) {
     ;
 
     py::class_<SparseParametricMdpSimplifier, std::shared_ptr<SparseParametricMdpSimplifier>>(m, "_SparseParametricMdpSimplifier", "Model simplifier for parametric MDPs")
-       .def("__init__", [](SparseParametricMdpSimplifier &instance, Mdp const& mdp) -> void {
-                new (&instance) SparseParametricMdpSimplifier(mdp);
-            }, py::arg("mdp"))
+       .def(py::init<Mdp const&>(), py::arg("mdp"))
        .def("simplify", [](SparseParametricMdpSimplifier &simplifier, storm::logic::Formula const& formula) -> bool {
                 return simplifier.simplify(formula);
             }, "Simplify model", py::arg("formula"))

--- a/src/pars/pla.cpp
+++ b/src/pars/pla.cpp
@@ -73,15 +73,15 @@ void define_pla(py::module& m) {
 
     // Region
     py::class_<Region, std::shared_ptr<Region>>(m, "ParameterRegion", "Parameter region")
-        .def("__init__", [](Region &instance, std::map<Region::VariableType, std::pair<Region::CoefficientType, Region::CoefficientType>> valuation) -> void {
+        .def(py::init([](std::map<Region::VariableType, std::pair<Region::CoefficientType, Region::CoefficientType>> valuation) {
                 Region::Valuation lowerValuation;
                 Region::Valuation upperValuation;
                 for (auto const& val : valuation) {
                     lowerValuation[val.first] = val.second.first;
                     upperValuation[val.first] = val.second.second;
                 }
-                new (&instance) Region(lowerValuation, upperValuation);
-            }, "Create region from valuation of var -> (lower_bound, upper_bound)", py::arg("valuation"))
+                return Region(lowerValuation, upperValuation);
+            }), "Create region from valuation of var -> (lower_bound, upper_bound)", py::arg("valuation"))
         .def_static("create_from_string", [](std::string const& regionString, std::set<Region::VariableType> const& variables, boost::optional<int> splittingThreshold = boost::none) -> Region {
                 return storm::api::parseRegion<storm::RationalFunction>(regionString, variables, splittingThreshold);
             }, "Create region from string", py::arg("region_string"), py::arg("variables"), py::arg("splitting_threshold") = boost::none)

--- a/src/utility/shortestPaths.cpp
+++ b/src/utility/shortestPaths.cpp
@@ -26,13 +26,13 @@ void define_ksp(py::module& m) {
 
     py::class_<Path>(m, "Path")
         // overload constructor rather than dealing with boost::optional
-        .def("__init__", [](Path &instance, state_t preNode, unsigned long preK, double distance) {
-                new (&instance) Path { boost::optional<state_t>(preNode), preK, distance };
-            }, "predecessorNode"_a, "predecessorK"_a, "distance"_a)
+        .def(py::init([](state_t preNode, unsigned long preK, double distance) {
+                return Path { boost::optional<state_t>(preNode), preK, distance };
+            }), "predecessorNode"_a, "predecessorK"_a, "distance"_a)
 
-        .def("__init__", [](Path &instance, unsigned long preK, double distance) {
-                new (&instance) Path { boost::none, preK, distance };
-            }, "predecessorK"_a, "distance"_a)
+        .def(py::init([](unsigned long preK, double distance) {
+                return Path { boost::none, preK, distance };
+            }), "predecessorK"_a, "distance"_a)
 
         .def(py::self == py::self, "Compares predecessor node and index, ignoring distance")
 


### PR DESCRIPTION
- replaced `__init__` by `py::init`