### PR TITLE
Remove python installation in CI

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -137,7 +137,7 @@ jobs:
           sudo docker exec storm apt-get update
           sudo docker exec storm apt-get upgrade -qqy
       - name: install dependencies
-        run: sudo docker exec storm apt-get install -qq -y maven uuid-dev python python3 virtualenv
+        run: sudo docker exec storm apt-get install -qq -y maven uuid-dev python3 virtualenv
       - name: Git clone
         run: |
           # git clone cannot clone individual commits based on a sha and some other refs


### PR DESCRIPTION
Package `python` is not available under Ubuntu 22.04 any more.