### PR TITLE
Added py::prepend to fix overlead order of __str__ for enums

### DIFF
--- a/src/pars/pla.cpp
+++ b/src/pars/pla.cpp
@@ -60,7 +60,7 @@ void define_pla(py::module& m) {
         .value("ALLSAT", storm::modelchecker::RegionResult::AllSat)
         .value("ALLVIOLATED", storm::modelchecker::RegionResult::AllViolated)
         .value("UNKNOWN", storm::modelchecker::RegionResult::Unknown)
-        .def("__str__", &streamToString<storm::modelchecker::RegionResult>)
+        .def("__str__", &streamToString<storm::modelchecker::RegionResult>, py::prepend() /* use custom method instead of default enum overload */)
     ;
 
     // RegionResultHypothesis
@@ -68,7 +68,7 @@ void define_pla(py::module& m) {
         .value("UNKNOWN", storm::modelchecker::RegionResultHypothesis::Unknown)
         .value("ALLSAT", storm::modelchecker::RegionResultHypothesis::AllSat)
         .value("ALLVIOLATED", storm::modelchecker::RegionResultHypothesis::AllViolated)
-        .def("__str__", &streamToString<storm::modelchecker::RegionResultHypothesis>)
+        .def("__str__", &streamToString<storm::modelchecker::RegionResultHypothesis>, py::prepend() /* use custom method instead of default enum overload */)
     ;
 
     // Region

--- a/tests/pars/test_pla.py
+++ b/tests/pars/test_pla.py
@@ -7,6 +7,12 @@ from configurations import pars
 
 @pars
 class TestPLA:
+    def test_to_string(self):
+        assert str(stormpy.pars.RegionResultHypothesis.UNKNOWN) == "Unknown"
+        assert str(stormpy.pars.RegionResultHypothesis.ALLSAT) == "AllSat?"
+        assert str(stormpy.pars.RegionResult.EXISTSVIOLATED) == "ExistsViolated"
+        assert str(stormpy.pars.RegionResult.ALLSAT) == "AllSat"
+
     def test_pla(self):
         program = stormpy.parse_prism_program(get_example_path("pdtmc", "brp16_2.pm"))
         prop = "P<=0.84 [F s=5 ]"


### PR DESCRIPTION
Fixes order of overloads for enums. See the the pycarl PR https://github.com/moves-rwth/pycarl/pull/17 for details.