### PR TITLE
Adaption to Storm changes

### DIFF
--- a/src/pomdp/transformations.cpp
+++ b/src/pomdp/transformations.cpp
@@ -4,6 +4,7 @@
 #include <storm-pomdp/transformer/BinaryPomdpTransformer.h>
 #include <storm-pomdp/transformer/ApplyFiniteSchedulerToPomdp.h>
 #include <storm-pomdp/transformer/ObservationTraceUnfolder.h>
+#include <storm/adapters/RationalFunctionAdapter.h>
 #include <storm/storage/expressions/ExpressionManager.h>
 
 template<typename ValueType>

--- a/src/storage/choiceorigins.cpp
+++ b/src/storage/choiceorigins.cpp
@@ -1,4 +1,5 @@
 #include "choiceorigins.h"
+#include "storm/adapters/JsonAdapter.h"
 #include "storm/storage/sparse/JaniChoiceOrigins.h"
 #include "storm/storage/sparse/PrismChoiceOrigins.h"
 #include "storm/storage/jani/Model.h"

--- a/src/storage/matrix.cpp
+++ b/src/storage/matrix.cpp
@@ -1,7 +1,7 @@
 #include "matrix.h"
+#include "storm/adapters/RationalFunctionAdapter.h"
 #include "storm/storage/SparseMatrix.h"
 #include "storm/storage/BitVector.h"
-
 #include "storm/utility/graph.h"
 #include "src/helpers.h"
 

--- a/src/storage/model.cpp
+++ b/src/storage/model.cpp
@@ -272,9 +272,9 @@ void define_sparse_model(py::module& m, std::string const& vtSuffix) {
     ;
 
     py::class_<SparseRewardModel<ValueType>>(m, ("Sparse" + vtSuffix + "RewardModel").c_str(), "Reward structure for sparse models")
-        .def(py::init<boost::optional<std::vector<ValueType>> const&, boost::optional<std::vector<ValueType>> const&,
-                boost::optional<storm::storage::SparseMatrix<ValueType>> const&>(), py::arg("optional_state_reward_vector") = boost::none,
-                py::arg("optional_state_action_reward_vector") = boost::none,  py::arg("optional_transition_reward_matrix") = boost::none)
+        .def(py::init<std::optional<std::vector<ValueType>> const&, std::optional<std::vector<ValueType>> const&,
+                std::optional<storm::storage::SparseMatrix<ValueType>> const&>(), py::arg("optional_state_reward_vector") = std::nullopt,
+                py::arg("optional_state_action_reward_vector") = std::nullopt,  py::arg("optional_transition_reward_matrix") = std::nullopt)
         .def_property_readonly("has_state_rewards", &SparseRewardModel<ValueType>::hasStateRewards)
         .def_property_readonly("has_state_action_rewards", &SparseRewardModel<ValueType>::hasStateActionRewards)
         .def_property_readonly("has_transition_rewards", &SparseRewardModel<ValueType>::hasTransitionRewards)

--- a/src/storage/model_components.cpp
+++ b/src/storage/model_components.cpp
@@ -1,5 +1,6 @@
 #include "model_components.h"
 
+#include "storm/adapters/RationalFunctionAdapter.h"
 #include "storm/models/sparse/StandardRewardModel.h"
 #include "storm/models/symbolic/StandardRewardModel.h"
 #include "storm/storage/sparse/ModelComponents.h"

--- a/src/storage/prism.cpp
+++ b/src/storage/prism.cpp
@@ -1,9 +1,11 @@
 #include "prism.h"
 #include <storm/storage/prism/Program.h>
 #include <boost/variant.hpp>
+#include <boost/algorithm/string/join.hpp>
 #include <random>
 #include "src/helpers.h"
 #include <storm/storage/expressions/ExpressionManager.h>
+#include <storm/storage/expressions/ExpressionEvaluator.h>
 #include <storm/storage/jani/Model.h>
 #include <storm/storage/jani/Property.h>
 #include <storm/storage/prism/OverlappingGuardAnalyser.h>
@@ -12,6 +14,7 @@
 #include <storm/generator/StateBehavior.h>
 #include <storm/generator/PrismNextStateGenerator.h>
 #include "storm/exceptions/NotSupportedException.h"
+#include "storm/exceptions/NotImplementedException.h"
 #include <storm/storage/expressions/SimpleValuation.h>
 #include "storm/exceptions/InvalidTypeException.h"
 #include "storm/exceptions/InvalidStateException.h"

--- a/src/storage/scheduler.cpp
+++ b/src/storage/scheduler.cpp
@@ -1,6 +1,7 @@
 #include "scheduler.h"
 #include "src/helpers.h"
 
+#include "storm/adapters/RationalFunctionAdapter.h"
 #include "storm/storage/Scheduler.h"
 
 template<typename ValueType>

--- a/src/storage/valuation.cpp
+++ b/src/storage/valuation.cpp
@@ -1,10 +1,12 @@
-#include <storm/storage/expressions/SimpleValuation.h>
 #include "valuation.h"
 #include "src/helpers.h"
 
-#include "storm/storage/sparse/StateValuations.h"
-#include "storm/storage/expressions/Variable.h"
+#include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/adapters/JsonAdapter.h"
 #include "storm/storage/expressions/ExpressionManager.h"
+#include "storm/storage/expressions/SimpleValuation.h"
+#include "storm/storage/expressions/Variable.h"
+#include "storm/storage/sparse/StateValuations.h"
 
 // Thin wrappers
 storm::json<storm::RationalNumber> toJson(storm::storage::sparse::StateValuations const& valuations, storm::storage::sparse::state_type const& stateIndex, boost::optional<std::set<storm::expressions::Variable>> const& selectedVariables) {


### PR DESCRIPTION
Replaced one instance of `boost::optional` with `std::optional` to adapt to https://github.com/moves-rwth/storm/pull/340.
More replacements will be needed if Storm replaces all `boost::optional`.