### PR TITLE
Fix parametric models doc ipynb to use pdtmc

### DIFF
--- a/doc/source/doc/parametric_models.ipynb
+++ b/doc/source/doc/parametric_models.ipynb
@@ -30,7 +30,7 @@
     ">>> import stormpy\n",
     ">>> import stormpy.examples\n",
     ">>> import stormpy.examples.files\n",
-    ">>> path = stormpy.examples.files.prism_dtmc_die\n",
+    ">>> path = stormpy.examples.files.prism_pdtmc_die\n",
     ">>> prism_program = stormpy.parse_prism_program(path)\n",
     ">>> formula_str = \"P=? [F s=7 & d=2]\"\n",
     ">>> properties = stormpy.parse_properties(formula_str, prism_program)\n",
@@ -77,7 +77,7 @@
     ">>> point = dict()\n",
     ">>> for x in parameters:\n",
     "...    print(x.name)\n",
-    "...    point[x] = 0.4\n",
+    "...    point[x] = stormpy.RationalRF(0.4)\n",
     ">>> instantiated_model = instantiator.instantiate(point)\n",
     ">>> result = stormpy.model_checking(instantiated_model, properties[0])"
    ]


### PR DESCRIPTION
The parametric models documentation ipynb was not using the pDTMC die file, so the model used in the example was not parametric. I fixed this and fixed the type of the point assignments to match the linked example python file. The notebook runs correctly now until the constraint collector cell.

This exposes an issue later on in the ipynb, however. When the constraint collector is called on the correctly typed model (pDTMC model), an error is thrown that I am struggling to parse. I'm not sure where or how to fix this, but it seems to be an orthogonal problem to the issues in the earlier cells, so it should be ok to merge these changes and then open an issue for this bug separately.

Error message about the constraints collector portion here:

```---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
TypeError: Unregistered type : carl::Formula<carl::MultivariatePolynomial<cln::cl_RA, carl::MonomialComparator<&(carl::Monomial::compareGradedLexical(std::__1::shared_ptr<carl::Monomial const> const&, std::__1::shared_ptr<carl::Monomial const> const&)), true>, carl::StdMultivariatePolynomialPolicies<carl::NoReasons, carl::NoAllocator> > >

The above exception was the direct cause of the following exception:

TypeError                                 Traceback (most recent call last)
Cell In[7], line 2
      1 collector = stormpy.ConstraintCollector(model)
----> 2 for formula in collector.wellformed_constraints:
      3     print(formula)
      4 for formula in collector.graph_preserving_constraints:

TypeError: Unable to convert function return value to a Python type! The signature was
	(arg0: stormpy.core.ConstraintCollector) -> Set[carl::Formula<carl::MultivariatePolynomial<cln::cl_RA, carl::MonomialComparator<&(carl::Monomial::compareGradedLexical(std::__1::shared_ptr<carl::Monomial const> const&, std::__1::shared_ptr<carl::Monomial const> const&)), true>, carl::StdMultivariatePolynomialPolicies<carl::NoReasons, carl::NoAllocator> > >]

Did you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,
<pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic
conversions are optional and require extra headers to be included
when compiling your pybind11 module.
```