### PR TITLE
Avoid import error in test if numpy is not present

### DIFF
--- a/tests/core/test_multiobjective.py
+++ b/tests/core/test_multiobjective.py
@@ -1,5 +1,4 @@
 import stormpy
-from stormpy.utility.multiobjective_plotting import prepare_multiobjective_result_for_plotting, plot_convex_pareto_curve_demo
 from helpers.helper import get_example_path
 
 from configurations import plotting, numpy_avail
@@ -23,6 +22,7 @@ class TestModelChecking:
     @numpy_avail
     def naive_api_double_with_plotting_test(self):
         import matplotlib.pyplot as plt
+        from stormpy.utility.multiobjective_plotting import prepare_multiobjective_result_for_plotting, plot_convex_pareto_curve_demo
 
         program = stormpy.parse_prism_program(get_example_path("mdp", "multiobjective1.nm"))
         properties = stormpy.parse_properties_for_prism_program("multi(Pmax=? [ F<=3 s=2 ],R{\"rew\"}max=? [ F s=2 ])", program)


### PR DESCRIPTION
We still need `numpy` as a dependency because it occurs in the Jupyter notebooks and throws an error if not present.