### PR TITLE
Patch to pybind11 to avoid issue with concat

### DIFF
--- a/resources/include_pybind11.cmake
+++ b/resources/include_pybind11.cmake
@@ -9,6 +9,7 @@ else()
         pybind11
         GIT_REPOSITORY https://github.com/pybind/pybind11
         GIT_TAG        "v${PYBIND_VERSION}"
+        PATCH_COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/resources/pybind11_${PYBIND_VERSION}.patch || git apply ${CMAKE_CURRENT_SOURCE_DIR}/resources/pybind11_${PYBIND_VERSION}.patch --reverse --check
     )
 
     FetchContent_MakeAvailable(pybind11)

--- a/resources/pybind11_2.10.0.patch
+++ b/resources/pybind11_2.10.0.patch
@@ -1,0 +1,22 @@
+diff --git a/include/pybind11/cast.h b/include/pybind11/cast.h
+index a0e32281..f132d096 100644
+--- a/include/pybind11/cast.h
++++ b/include/pybind11/cast.h
+@@ -657,7 +657,7 @@ public:
+     }
+ 
+     static constexpr auto name
+-        = const_name("Tuple[") + concat(make_caster<Ts>::name...) + const_name("]");
++        = const_name("Tuple[") + pybind11::detail::concat(make_caster<Ts>::name...) + const_name("]");
+ 
+     template <typename T>
+     using cast_op_type = type;
+@@ -1399,7 +1399,7 @@ public:
+     static_assert(args_pos == -1 || args_pos == constexpr_first<argument_is_args, Args...>(),
+                   "py::args cannot be specified more than once");
+ 
+-    static constexpr auto arg_names = concat(type_descr(make_caster<Args>::name)...);
++    static constexpr auto arg_names = pybind11::detail::concat(type_descr(make_caster<Args>::name)...);
+ 
+     bool load_args(function_call &call) { return load_impl_sequence(call, indices{}); }
+ 

--- a/resources/pybind11_2.11.1.patch
+++ b/resources/pybind11_2.11.1.patch
@@ -1,0 +1,22 @@
+diff --git a/include/pybind11/cast.h b/include/pybind11/cast.h
+index db393411..117680a1 100644
+--- a/include/pybind11/cast.h
++++ b/include/pybind11/cast.h
+@@ -661,7 +661,7 @@ public:
+     }
+ 
+     static constexpr auto name
+-        = const_name("Tuple[") + concat(make_caster<Ts>::name...) + const_name("]");
++        = const_name("Tuple[") + pybind11::detail::concat(make_caster<Ts>::name...) + const_name("]");
+ 
+     template <typename T>
+     using cast_op_type = type;
+@@ -1438,7 +1438,7 @@ public:
+     static_assert(args_pos == -1 || args_pos == constexpr_first<argument_is_args, Args...>(),
+                   "py::args cannot be specified more than once");
+ 
+-    static constexpr auto arg_names = concat(type_descr(make_caster<Args>::name)...);
++    static constexpr auto arg_names = pybind11::detail::concat(type_descr(make_caster<Args>::name)...);
+ 
+     bool load_args(function_call &call) { return load_impl_sequence(call, indices{}); }
+ 


### PR DESCRIPTION
Add namespace `detail::concat` in `pybind11/include/pybind11/cast.h`. This resolves https://github.com/moves-rwth/stormpy/issues/140 for now.
We might want to create a better solution in the future.