### PR TITLE
Update 'observations' to 'observability_classes'

### DIFF
--- a/doc/source/doc/models/building_mdps.ipynb
+++ b/doc/source/doc/models/building_mdps.ipynb
@@ -286,7 +286,7 @@
     "## Partially observable Markov decision process (POMDPs)\n",
     "\n",
     "To build a partially observable Markov decision process (POMDP),\n",
-    "components.observations can be set to a list of numbers that defines the status of the observables in each state."
+    "`components.observability_classes` can be set to a list of numbers that defines the status of the observables in each state."
    ]
   }
  ],


### PR DESCRIPTION
For building POMDPs, the attribute name for setting the observations in the `stormpy.SparseModelComponents` class in Stormpy is `observability_classes`.

This change prevents readers' confusion following `building_mdps.ipynb` (like myself).