### PR TITLE
Revise stormpy modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,7 @@ function(build_module MOD_NAME # Module name
     pybind11_add_module(${MOD_NAME} "${CMAKE_CURRENT_SOURCE_DIR}/src/${MOD_FILE}" ${${MOD_NAME}_SOURCES})
     target_include_directories(${MOD_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${ADDITIONAL_INCLUDES} ${CMAKE_CURRENT_BINARY_DIR}/src)
     target_link_libraries(${MOD_NAME} PRIVATE ${ADDITIONAL_LIBS})
-    set_target_properties(${MOD_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${OUT_DIR}" OUTPUT_NAME "${OUT_NAME}")
+    set_target_properties(${MOD_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${OUT_DIR}" OUTPUT_NAME "_${OUT_NAME}")
     install(TARGETS ${MOD_NAME} DESTINATION ${OUT_DIR})
 endfunction(build_module)
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -16,6 +16,7 @@ Work in progress!
    api/dft
    api/gspn
    api/pars
+   api/pomdp
 
    api/pycarl/core
    api/pycarl/convert

--- a/doc/source/api/core.rst
+++ b/doc/source/api/core.rst
@@ -5,3 +5,4 @@ Stormpy.core
    :members:
    :undoc-members:
    :imported-members:
+   :exclude-members: deprecated

--- a/doc/source/api/dft.rst
+++ b/doc/source/api/dft.rst
@@ -5,3 +5,4 @@ Stormpy.dft
    :members:
    :undoc-members:
    :imported-members:
+   :exclude-members: deprecated

--- a/doc/source/api/exceptions.rst
+++ b/doc/source/api/exceptions.rst
@@ -5,3 +5,4 @@ Stormpy.exceptions
    :members:
    :undoc-members:
    :imported-members:
+   :exclude-members: deprecated

--- a/doc/source/api/gspn.rst
+++ b/doc/source/api/gspn.rst
@@ -5,3 +5,4 @@ Stormpy.gspn
    :members:
    :undoc-members:
    :imported-members:
+   :exclude-members: deprecated

--- a/doc/source/api/info.rst
+++ b/doc/source/api/info.rst
@@ -5,3 +5,4 @@ Stormpy.info
    :members:
    :undoc-members:
    :imported-members:
+   :exclude-members: deprecated

--- a/doc/source/api/logic.rst
+++ b/doc/source/api/logic.rst
@@ -5,3 +5,4 @@ Stormpy.logic
    :members:
    :undoc-members:
    :imported-members:
+   :exclude-members: deprecated

--- a/doc/source/api/pars.rst
+++ b/doc/source/api/pars.rst
@@ -5,3 +5,4 @@ Stormpy.pars
    :members:
    :undoc-members:
    :imported-members:
+   :exclude-members: deprecated

--- a/doc/source/api/pomdp.rst
+++ b/doc/source/api/pomdp.rst
@@ -1,0 +1,7 @@
+Stormpy.pomdp
+**************************
+
+.. automodule:: stormpy.pomdp
+   :members:
+   :undoc-members:
+   :imported-members:

--- a/doc/source/api/pycarl/convert.rst
+++ b/doc/source/api/pycarl/convert.rst
@@ -1,11 +1,12 @@
 Pycarl convert
-************************
+**************************
 
 
 Number conversion
 ---------------------------
 
 .. automodule:: stormpy.pycarl.convert
-    :members:
-    :undoc-members:
-    :imported-members:
+   :members:
+   :undoc-members:
+   :imported-members:
+   :exclude-members: deprecated

--- a/doc/source/api/pycarl/core.rst
+++ b/doc/source/api/pycarl/core.rst
@@ -1,27 +1,30 @@
 Pycarl core
-************************
+**************************
 
 
 Number independent types
 ---------------------------
 
 .. automodule:: stormpy.pycarl
-    :members:
-    :undoc-members:
-    :imported-members:
+   :members:
+   :undoc-members:
+   :imported-members:
+   :exclude-members: deprecated
 
 Number dependent types (gmp)
 ------------------------------
 
 .. automodule:: stormpy.pycarl.gmp
-    :members:
-    :undoc-members:
-    :imported-members:
+   :members:
+   :undoc-members:
+   :imported-members:
+   :exclude-members: deprecated
 
 Number dependent types (cln)
 ------------------------------
 
 .. automodule:: stormpy.pycarl.cln
-    :members:
-    :undoc-members:
-    :imported-members:
+   :members:
+   :undoc-members:
+   :imported-members:
+   :exclude-members: deprecated

--- a/doc/source/api/pycarl/formula.rst
+++ b/doc/source/api/pycarl/formula.rst
@@ -1,27 +1,30 @@
 Pycarl formula
-************************
+**************************
 
 
 Number independent types
 ---------------------------
 
 .. automodule:: stormpy.pycarl.formula
-    :members:
-    :undoc-members:
-    :imported-members:
+   :members:
+   :undoc-members:
+   :imported-members:
+   :exclude-members: deprecated
 
 Number dependent types (gmp)
 ------------------------------
 
 .. automodule:: stormpy.pycarl.gmp.formula
-    :members:
-    :undoc-members:
-    :imported-members:
+   :members:
+   :undoc-members:
+   :imported-members:
+   :exclude-members: deprecated
 
 Number dependent types (cln)
 ------------------------------
 
 .. automodule:: stormpy.pycarl.cln.formula
-    :members:
-    :undoc-members:
-    :imported-members:
+   :members:
+   :undoc-members:
+   :imported-members:
+   :exclude-members: deprecated

--- a/doc/source/api/pycarl/parse.rst
+++ b/doc/source/api/pycarl/parse.rst
@@ -1,27 +1,30 @@
 Pycarl parse
-************************
+**************************
 
 
 Number independent types
 ---------------------------
 
 .. automodule:: stormpy.pycarl.parse
-    :members:
-    :undoc-members:
-    :imported-members:
+   :members:
+   :undoc-members:
+   :imported-members:
+   :exclude-members: deprecated
 
 Number dependent types (gmp)
 ------------------------------
 
 .. automodule:: stormpy.pycarl.gmp.parse
-    :members:
-    :undoc-members:
-    :imported-members:
+   :members:
+   :undoc-members:
+   :imported-members:
+   :exclude-members: deprecated
 
 Number dependent types (cln)
 ------------------------------
 
 .. automodule:: stormpy.pycarl.cln.parse
-    :members:
-    :undoc-members:
-    :imported-members:
+   :members:
+   :undoc-members:
+   :imported-members:
+   :exclude-members: deprecated

--- a/doc/source/api/storage.rst
+++ b/doc/source/api/storage.rst
@@ -5,3 +5,4 @@ Stormpy.storage
    :members:
    :undoc-members:
    :imported-members:
+   :exclude-members: deprecated

--- a/doc/source/api/utility.rst
+++ b/doc/source/api/utility.rst
@@ -5,3 +5,4 @@ Stormpy.utility
    :members:
    :undoc-members:
    :imported-members:
+   :exclude-members: deprecated

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,6 +29,9 @@ extensions = [
 ]
 autosectionlabel_prefix_document = True
 
+# Autodoc options
+autoclass_content = "both"  # Add documentation for both the class and __init__
+
 templates_path = ["_templates"]
 exclude_patterns = []
 

--- a/examples/pomdp/01-pomdps.py
+++ b/examples/pomdp/01-pomdps.py
@@ -77,7 +77,7 @@ def example_parametric_models_01():
 
     export_pmc = False  # Set to True to export the pMC as drn.
     if export_pmc:
-        export_options = stormpy.core.DirectEncodingOptions()
+        export_options = stormpy.DirectEncodingOptions()
         export_options.allow_placeholders = False
         stormpy.export_to_drn(pmc, "test.out", export_options)
 

--- a/lib/stormpy/__init__.py
+++ b/lib/stormpy/__init__.py
@@ -512,10 +512,10 @@ def topological_sort(model, forward=True, initial=[]):
     :return: A topological sort of the states
     """
     matrix = model.transition_matrix if forward else model.backward_transition_matrix
-    if isinstance(model, storage._SparseParametricModel):
-        return storage._topological_sort_rf(matrix, initial)
-    elif isinstance(model, storage._SparseModel):
-        return storage._topological_sort_double(matrix, initial)
+    if isinstance(model, storage._storage._SparseParametricModel):
+        return storage._storage._topological_sort_rf(matrix, initial)
+    elif isinstance(model, storage._storage._SparseModel):
+        return storage._storage._topological_sort_double(matrix, initial)
     else:
         raise stormpy.exceptions.StormError("Unknown kind of model.")
 

--- a/lib/stormpy/__init__.py
+++ b/lib/stormpy/__init__.py
@@ -10,7 +10,7 @@ from .core import *
 from . import storage
 from .storage import *
 from .logic import *
-from .exceptions import *
+from . import exceptions
 
 try:
     from ._version import __version__
@@ -41,7 +41,7 @@ def _convert_sparse_model(model, parametric=False):
         elif model.model_type == ModelType.MA:
             return model._as_sparse_pma()
         else:
-            raise StormError("Not supported parametric model constructed")
+            raise stormpy.exceptions.StormError("Not supported parametric model constructed")
     else:
         assert not model.supports_parameters
         if model.model_type == ModelType.DTMC:
@@ -57,7 +57,7 @@ def _convert_sparse_model(model, parametric=False):
         elif model.model_type == ModelType.SMG:
             return model._as_sparse_smg()
         else:
-            raise StormError("Not supported non-parametric model constructed")
+            raise stormpy.exceptions.StormError("Not supported non-parametric model constructed")
 
 
 def _convert_symbolic_model(model, parametric=False):
@@ -78,7 +78,7 @@ def _convert_symbolic_model(model, parametric=False):
         elif model.model_type == ModelType.MA:
             return model._as_symbolic_pma()
         else:
-            raise StormError("Not supported parametric model constructed")
+            raise stormpy.exceptions.StormError("Not supported parametric model constructed")
     else:
         assert not model.supports_parameters
         if model.model_type == ModelType.DTMC:
@@ -90,7 +90,7 @@ def _convert_symbolic_model(model, parametric=False):
         elif model.model_type == ModelType.MA:
             return model._as_symbolic_ma()
         else:
-            raise StormError("Not supported non-parametric model constructed")
+            raise stormpy.exceptions.StormError("Not supported non-parametric model constructed")
 
 
 def build_model(symbolic_description, properties=None):
@@ -124,7 +124,7 @@ def build_sparse_model(symbolic_description, properties=None):
     :return: Model in sparse representation.
     """
     if not symbolic_description.undefined_constants_are_graph_preserving:
-        raise StormError("Program still contains undefined constants")
+        raise stormpy.exceptions.StormError("Program still contains undefined constants")
 
     if properties:
         formulae = [(prop.raw_formula if isinstance(prop, Property) else prop) for prop in properties]
@@ -143,7 +143,7 @@ def build_sparse_parametric_model(symbolic_description, properties=None):
     :return: Parametric model in sparse representation.
     """
     if not symbolic_description.undefined_constants_are_graph_preserving:
-        raise StormError("Program still contains undefined constants")
+        raise stormpy.exceptions.StormError("Program still contains undefined constants")
 
     if properties:
         formulae = [(prop.raw_formula if isinstance(prop, Property) else prop) for prop in properties]
@@ -162,7 +162,7 @@ def build_symbolic_model(symbolic_description, properties=None):
     :return: Model in symbolic representation.
     """
     if not symbolic_description.undefined_constants_are_graph_preserving:
-        raise StormError("Program still contains undefined constants")
+        raise stormpy.exceptions.StormError("Program still contains undefined constants")
 
     if properties:
         formulae = [(prop.raw_formula if isinstance(prop, Property) else prop) for prop in properties]
@@ -181,7 +181,7 @@ def build_symbolic_parametric_model(symbolic_description, properties=None):
     :return: Parametric model in symbolic representation.
     """
     if not symbolic_description.undefined_constants_are_graph_preserving:
-        raise StormError("Program still contains undefined constants")
+        raise stormpy.exceptions.StormError("Program still contains undefined constants")
 
     if properties:
         formulae = [(prop.raw_formula if isinstance(prop, Property) else prop) for prop in properties]
@@ -230,7 +230,7 @@ def build_interval_model_from_drn(file, options=DirectEncodingParserOptions()):
     elif intermediate.model_type == ModelType.POMDP:
         return intermediate._as_sparse_ipomdp()
     else:
-        raise StormError("Not supported interval model constructed")
+        raise stormpy.exceptions.StormError("Not supported interval model constructed")
 
 
 def perform_bisimulation(model, properties, bisimulation_type):
@@ -297,7 +297,7 @@ def model_checking(model, property, only_initial_states=False, extract_scheduler
     else:
         assert model.is_symbolic_model
         if extract_scheduler:
-            raise StormError("Model checking based on dd engine does not support extracting schedulers right now.")
+            raise stormpy.exceptions.StormError("Model checking based on dd engine does not support extracting schedulers right now.")
         return check_model_dd(model, property, only_initial_states=only_initial_states, environment=environment)
 
 
@@ -477,7 +477,7 @@ def compute_prob01_states(model, phi_states, psi_states):
     :param BitVector psi_states: Target states
     """
     if model.model_type != ModelType.DTMC:
-        raise StormError("Prob 01 is only defined for DTMCs -- model must be a DTMC")
+        raise stormpy.exceptions.StormError("Prob 01 is only defined for DTMCs -- model must be a DTMC")
 
     if model.supports_parameters:
         return core._compute_prob01states_rationalfunc(model, phi_states, psi_states)
@@ -517,7 +517,7 @@ def topological_sort(model, forward=True, initial=[]):
     elif isinstance(model, storage._SparseModel):
         return storage._topological_sort_double(matrix, initial)
     else:
-        raise StormError("Unknown kind of model.")
+        raise stormpy.exceptions.StormError("Unknown kind of model.")
 
 
 def get_reachable_states(model, initial_states, constraint_states, target_states, maximal_steps=None, choice_filter=None):
@@ -628,7 +628,7 @@ def parse_properties(properties, context=None, filters=None):
     elif type(context) == storage.JaniModel:
         return core.parse_properties_for_jani_model(properties, context, filters)
     else:
-        raise StormError("Unclear context. Please pass a symbolic model description")
+        raise stormpy.exceptions.StormError("Unclear context. Please pass a symbolic model description")
 
 
 def export_to_drn(model, file, options=DirectEncodingOptions()):

--- a/lib/stormpy/__init__.py
+++ b/lib/stormpy/__init__.py
@@ -1,5 +1,3 @@
-import sys
-
 from ._config import *
 
 from . import _core

--- a/lib/stormpy/__init__.py
+++ b/lib/stormpy/__init__.py
@@ -5,8 +5,8 @@ if sys.version_info[0] == 2:
 
 from ._config import *
 
-from . import core
-from .core import *
+from . import _core
+from ._core import *
 from . import storage
 from .storage import *
 from .logic import *
@@ -18,7 +18,7 @@ except ImportError:
     # We're running in a tree that doesn't have a _version.py, so we don't know what our version is.
     __version__ = "unknown"
 
-core._set_up("")
+_core._set_up("")
 
 
 def _convert_sparse_model(model, parametric=False):
@@ -128,9 +128,9 @@ def build_sparse_model(symbolic_description, properties=None):
 
     if properties:
         formulae = [(prop.raw_formula if isinstance(prop, Property) else prop) for prop in properties]
-        intermediate = core._build_sparse_model_from_symbolic_description(symbolic_description, formulae)
+        intermediate = _core._build_sparse_model_from_symbolic_description(symbolic_description, formulae)
     else:
-        intermediate = core._build_sparse_model_from_symbolic_description(symbolic_description)
+        intermediate = _core._build_sparse_model_from_symbolic_description(symbolic_description)
     return _convert_sparse_model(intermediate, parametric=False)
 
 
@@ -147,9 +147,9 @@ def build_sparse_parametric_model(symbolic_description, properties=None):
 
     if properties:
         formulae = [(prop.raw_formula if isinstance(prop, Property) else prop) for prop in properties]
-        intermediate = core._build_sparse_parametric_model_from_symbolic_description(symbolic_description, formulae)
+        intermediate = _core._build_sparse_parametric_model_from_symbolic_description(symbolic_description, formulae)
     else:
-        intermediate = core._build_sparse_parametric_model_from_symbolic_description(symbolic_description)
+        intermediate = _core._build_sparse_parametric_model_from_symbolic_description(symbolic_description)
     return _convert_sparse_model(intermediate, parametric=True)
 
 
@@ -166,9 +166,9 @@ def build_symbolic_model(symbolic_description, properties=None):
 
     if properties:
         formulae = [(prop.raw_formula if isinstance(prop, Property) else prop) for prop in properties]
-        intermediate = core._build_symbolic_model_from_symbolic_description(symbolic_description, formulae)
+        intermediate = _core._build_symbolic_model_from_symbolic_description(symbolic_description, formulae)
     else:
-        intermediate = core._build_symbolic_model_from_symbolic_description(symbolic_description)
+        intermediate = _core._build_symbolic_model_from_symbolic_description(symbolic_description)
     return _convert_symbolic_model(intermediate, parametric=False)
 
 
@@ -185,9 +185,9 @@ def build_symbolic_parametric_model(symbolic_description, properties=None):
 
     if properties:
         formulae = [(prop.raw_formula if isinstance(prop, Property) else prop) for prop in properties]
-        intermediate = core._build_symbolic_parametric_model_from_symbolic_description(symbolic_description, formulae)
+        intermediate = _core._build_symbolic_parametric_model_from_symbolic_description(symbolic_description, formulae)
     else:
-        intermediate = core._build_symbolic_parametric_model_from_symbolic_description(symbolic_description)
+        intermediate = _core._build_symbolic_parametric_model_from_symbolic_description(symbolic_description)
     return _convert_symbolic_model(intermediate, parametric=True)
 
 
@@ -199,7 +199,7 @@ def build_model_from_drn(file, options=DirectEncodingParserOptions()):
     :param DirectEncodingParserOptions: Options for the parser.
     :return: Model in sparse representation.
     """
-    intermediate = core._build_sparse_model_from_drn(file, options)
+    intermediate = _core._build_sparse_model_from_drn(file, options)
     return _convert_sparse_model(intermediate, parametric=False)
 
 
@@ -211,7 +211,7 @@ def build_parametric_model_from_drn(file, options=DirectEncodingParserOptions())
     :param DirectEncodingParserOptions: Options for the parser.
     :return: Parametric model in sparse representation.
     """
-    intermediate = core._build_sparse_parametric_model_from_drn(file, options)
+    intermediate = _core._build_sparse_parametric_model_from_drn(file, options)
     return _convert_sparse_model(intermediate, parametric=True)
 
 
@@ -223,7 +223,7 @@ def build_interval_model_from_drn(file, options=DirectEncodingParserOptions()):
     :param DirectEncodingParserOptions: Options for the parser.
     :return: Interval model in sparse representation.
     """
-    intermediate = core._build_sparse_interval_model_from_drn(file, options)
+    intermediate = _core._build_sparse_interval_model_from_drn(file, options)
     assert intermediate.supports_uncertainty
     if intermediate.model_type == ModelType.MDP:
         return intermediate._as_sparse_imdp()
@@ -254,9 +254,9 @@ def perform_sparse_bisimulation(model, properties, bisimulation_type):
     """
     formulae = [(prop.raw_formula if isinstance(prop, Property) else prop) for prop in properties]
     if model.supports_parameters:
-        return core._perform_parametric_bisimulation(model, formulae, bisimulation_type)
+        return _core._perform_parametric_bisimulation(model, formulae, bisimulation_type)
     else:
-        return core._perform_bisimulation(model, formulae, bisimulation_type)
+        return _core._perform_bisimulation(model, formulae, bisimulation_type)
 
 
 def perform_symbolic_bisimulation(model, properties, quotient_format=stormpy.QuotientFormat.DD):
@@ -270,9 +270,9 @@ def perform_symbolic_bisimulation(model, properties, quotient_format=stormpy.Quo
     formulae = [(prop.raw_formula if isinstance(prop, Property) else prop) for prop in properties]
     bisimulation_type = BisimulationType.STRONG
     if model.supports_parameters:
-        return core._perform_symbolic_parametric_bisimulation(model, formulae, bisimulation_type, quotient_format)
+        return _core._perform_symbolic_parametric_bisimulation(model, formulae, bisimulation_type, quotient_format)
     else:
-        return core._perform_symbolic_bisimulation(model, formulae, bisimulation_type, quotient_format)
+        return _core._perform_symbolic_bisimulation(model, formulae, bisimulation_type, quotient_format)
 
 
 def model_checking(model, property, only_initial_states=False, extract_scheduler=False, force_fully_observable=False, environment=Environment()):
@@ -326,43 +326,43 @@ def check_model_sparse(model, property, only_initial_states=False, extract_sched
             elif model.supports_uncertainty:
                 raise NotImplementedError("Model checking of partially observable models is not supported for interval models.")
             elif model.is_exact:
-                task = core.ExactCheckTask(formula, only_initial_states)
+                task = _core.ExactCheckTask(formula, only_initial_states)
                 task.set_produce_schedulers(extract_scheduler)
                 if hint:
                     task.set_hint(hint)
-                return core._exact_model_checking_fully_observable(model, task, environment=environment)
+                return _core._exact_model_checking_fully_observable(model, task, environment=environment)
             else:
-                task = core.CheckTask(formula, only_initial_states)
+                task = _core.CheckTask(formula, only_initial_states)
                 task.set_produce_schedulers(extract_scheduler)
                 if hint:
                     task.set_hint(hint)
-                return core._model_checking_fully_observable(model, task, environment=environment)
+                return _core._model_checking_fully_observable(model, task, environment=environment)
         else:
             raise RuntimeError("Model checking of partially observable models is handled via dedicated methods, unless the force fully-observable is set.")
 
     if model.supports_parameters:
-        task = core.ParametricCheckTask(formula, only_initial_states)
+        task = _core.ParametricCheckTask(formula, only_initial_states)
         task.set_produce_schedulers(extract_scheduler)
         if hint:
             task.set_hint(hint)
-        return core._parametric_model_checking_sparse_engine(model, task, environment=environment)
+        return _core._parametric_model_checking_sparse_engine(model, task, environment=environment)
     else:
         if model.is_exact:
             if formula.is_multi_objective_formula:
-                return core._multi_objective_model_checking_exact(model, formula, environment=environment)
-            task = core.ExactCheckTask(formula, only_initial_states)
+                return _core._multi_objective_model_checking_exact(model, formula, environment=environment)
+            task = _core.ExactCheckTask(formula, only_initial_states)
             task.set_produce_schedulers(extract_scheduler)
             if hint:
                 task.set_hint(hint)
-            return core._exact_model_checking_sparse_engine(model, task, environment=environment)
+            return _core._exact_model_checking_sparse_engine(model, task, environment=environment)
         else:
             if formula.is_multi_objective_formula:
-                return core._multi_objective_model_checking_double(model, formula, environment=environment)
-            task = core.CheckTask(formula, only_initial_states)
+                return _core._multi_objective_model_checking_double(model, formula, environment=environment)
+            task = _core.CheckTask(formula, only_initial_states)
             task.set_produce_schedulers(extract_scheduler)
             if hint:
                 task.set_hint(hint)
-            return core._model_checking_sparse_engine(model, task, environment=environment)
+            return _core._model_checking_sparse_engine(model, task, environment=environment)
 
 
 def check_model_dd(model, property, only_initial_states=False, environment=Environment()):
@@ -380,11 +380,11 @@ def check_model_dd(model, property, only_initial_states=False, environment=Envir
         formula = property
 
     if model.supports_parameters:
-        task = core.ParametricCheckTask(formula, only_initial_states)
-        return core._parametric_model_checking_dd_engine(model, task, environment=environment)
+        task = _core.ParametricCheckTask(formula, only_initial_states)
+        return _core._parametric_model_checking_dd_engine(model, task, environment=environment)
     else:
-        task = core.CheckTask(formula, only_initial_states)
-        return core._model_checking_dd_engine(model, task, environment=environment)
+        task = _core.CheckTask(formula, only_initial_states)
+        return _core._model_checking_dd_engine(model, task, environment=environment)
 
 
 def check_model_hybrid(model, property, only_initial_states=False, environment=Environment()):
@@ -402,11 +402,11 @@ def check_model_hybrid(model, property, only_initial_states=False, environment=E
         formula = property
 
     if model.supports_parameters:
-        task = core.ParametricCheckTask(formula, only_initial_states)
-        return core._parametric_model_checking_hybrid_engine(model, task, environment=environment)
+        task = _core.ParametricCheckTask(formula, only_initial_states)
+        return _core._parametric_model_checking_hybrid_engine(model, task, environment=environment)
     else:
-        task = core.CheckTask(formula, only_initial_states)
-        return core._model_checking_hybrid_engine(model, task, environment=environment)
+        task = _core.CheckTask(formula, only_initial_states)
+        return _core._model_checking_hybrid_engine(model, task, environment=environment)
 
 
 def transform_to_sparse_model(model):
@@ -416,9 +416,9 @@ def transform_to_sparse_model(model):
     :return: Sparse model.
     """
     if model.supports_parameters:
-        return core._transform_to_sparse_parametric_model(model)
+        return _core._transform_to_sparse_parametric_model(model)
     else:
-        return core._transform_to_sparse_model(model)
+        return _core._transform_to_sparse_model(model)
 
 
 def transform_to_discrete_time_model(model, properties):
@@ -430,9 +430,9 @@ def transform_to_discrete_time_model(model, properties):
     """
     formulae = [(prop.raw_formula if isinstance(prop, Property) else prop) for prop in properties]
     if model.supports_parameters:
-        return core._transform_to_discrete_time_parametric_model(model, formulae)
+        return _core._transform_to_discrete_time_parametric_model(model, formulae)
     else:
-        return core._transform_to_discrete_time_model(model, formulae)
+        return _core._transform_to_discrete_time_model(model, formulae)
 
 
 def eliminate_non_markovian_chains(ma, properties, label_behavior):
@@ -445,15 +445,15 @@ def eliminate_non_markovian_chains(ma, properties, label_behavior):
     """
     formulae = [(prop.raw_formula if isinstance(prop, Property) else prop) for prop in properties]
     if ma.supports_parameters:
-        return core._eliminate_non_markovian_chains_parametric(ma, formulae, label_behavior)
+        return _core._eliminate_non_markovian_chains_parametric(ma, formulae, label_behavior)
     else:
-        return core._eliminate_non_markovian_chains(ma, formulae, label_behavior)
+        return _core._eliminate_non_markovian_chains(ma, formulae, label_behavior)
 
 
 def prob01min_states(model, eventually_formula):
     assert type(eventually_formula) == logic.EventuallyFormula
     labelform = eventually_formula.subformula
-    labelprop = core.Property("label-prop", labelform)
+    labelprop = _core.Property("label-prop", labelform)
     phiStates = BitVector(model.nr_states, True)
     psiStates = model_checking(model, labelprop).get_truth_values()
     return compute_prob01min_states(model, phiStates, psiStates)
@@ -462,7 +462,7 @@ def prob01min_states(model, eventually_formula):
 def prob01max_states(model, eventually_formula):
     assert type(eventually_formula) == logic.EventuallyFormula
     labelform = eventually_formula.subformula
-    labelprop = core.Property("label-prop", labelform)
+    labelprop = _core.Property("label-prop", labelform)
     phiStates = BitVector(model.nr_states, True)
     psiStates = model_checking(model, labelprop).get_truth_values()
     return compute_prob01max_states(model, phiStates, psiStates)
@@ -480,27 +480,27 @@ def compute_prob01_states(model, phi_states, psi_states):
         raise stormpy.exceptions.StormError("Prob 01 is only defined for DTMCs -- model must be a DTMC")
 
     if model.supports_parameters:
-        return core._compute_prob01states_rationalfunc(model, phi_states, psi_states)
+        return _core._compute_prob01states_rationalfunc(model, phi_states, psi_states)
     else:
-        return core._compute_prob01states_double(model, phi_states, psi_states)
+        return _core._compute_prob01states_double(model, phi_states, psi_states)
 
 
 def compute_prob01min_states(model, phi_states, psi_states):
     if model.model_type == ModelType.DTMC:
         return compute_prob01_states(model, phi_states, psi_states)
     if model.supports_parameters:
-        return core._compute_prob01states_min_rationalfunc(model, phi_states, psi_states)
+        return _core._compute_prob01states_min_rationalfunc(model, phi_states, psi_states)
     else:
-        return core._compute_prob01states_min_double(model, phi_states, psi_states)
+        return _core._compute_prob01states_min_double(model, phi_states, psi_states)
 
 
 def compute_prob01max_states(model, phi_states, psi_states):
     if model.model_type == ModelType.DTMC:
         return compute_prob01_states(model, phi_states, psi_states)
     if model.supports_parameters:
-        return core._compute_prob01states_max_rationalfunc(model, phi_states, psi_states)
+        return _core._compute_prob01states_max_rationalfunc(model, phi_states, psi_states)
     else:
-        return core._compute_prob01states_max_double(model, phi_states, psi_states)
+        return _core._compute_prob01states_max_double(model, phi_states, psi_states)
 
 
 def topological_sort(model, forward=True, initial=[]):
@@ -533,10 +533,10 @@ def get_reachable_states(model, initial_states, constraint_states, target_states
     :return:
     """
     if model.supports_parameters:
-        return core._get_reachable_states_rf(model, initial_states, constraint_states, target_states, maximal_steps, choice_filter)
+        return _core._get_reachable_states_rf(model, initial_states, constraint_states, target_states, maximal_steps, choice_filter)
     if model.is_exact:
-        return core._get_reachable_states_exact(model, initial_states, constraint_states, target_states, maximal_steps, choice_filter)
-    return core._get_reachable_states_double(model, initial_states, constraint_states, target_states, maximal_steps, choice_filter)
+        return _core._get_reachable_states_exact(model, initial_states, constraint_states, target_states, maximal_steps, choice_filter)
+    return _core._get_reachable_states_double(model, initial_states, constraint_states, target_states, maximal_steps, choice_filter)
 
 
 def compute_expected_number_of_visits(environment, model):
@@ -550,8 +550,8 @@ def compute_expected_number_of_visits(environment, model):
     if model.supports_parameters:
         raise NotImplementedError("Expected number of visits is not implemented for parametric models")
     if model.is_exact:
-        return core._compute_expected_number_of_visits_exact(environment, model)
-    return core._compute_expected_number_of_visits_double(environment, model)
+        return _core._compute_expected_number_of_visits_exact(environment, model)
+    return _core._compute_expected_number_of_visits_double(environment, model)
 
 
 def compute_steady_state_distribution(environment, model):
@@ -565,8 +565,8 @@ def compute_steady_state_distribution(environment, model):
     if model.supports_parameters:
         raise NotImplementedError("Steady-state distribution is not implemented for parametric models")
     if model.is_exact:
-        return core._compute_steady_state_distribution_exact(environment, model)
-    return core._compute_steady_state_distribution_double(environment, model)
+        return _core._compute_steady_state_distribution_exact(environment, model)
+    return _core._compute_steady_state_distribution_double(environment, model)
 
 
 def construct_submodel(model, states, actions, keep_unreachable_states=True, options=SubsystemBuilderOptions()):
@@ -580,10 +580,10 @@ def construct_submodel(model, states, actions, keep_unreachable_states=True, opt
     :return: A model with fewer states/actions
     """
     if model.supports_parameters:
-        return core._construct_subsystem_RatFunc(model, states, actions, keep_unreachable_states, options)
+        return _core._construct_subsystem_RatFunc(model, states, actions, keep_unreachable_states, options)
     if model.is_exact:
-        return core._construct_subsystem_Exact(model, states, actions, keep_unreachable_states, options)
-    return core._construct_subsystem_Double(model, states, actions, keep_unreachable_states, options)
+        return _core._construct_subsystem_Exact(model, states, actions, keep_unreachable_states, options)
+    return _core._construct_subsystem_Double(model, states, actions, keep_unreachable_states, options)
 
 
 def eliminate_ECs(matrix, subsystem, possible_ecs, add_sink_row_states, add_self_loop_at_sink_states=False):
@@ -605,7 +605,7 @@ def eliminate_ECs(matrix, subsystem, possible_ecs, add_sink_row_states, add_self
     assert matrix.nr_rows == possible_ecs.size(), "possible_ecs vector should have an entry for every row."
     assert matrix.nr_columns == add_sink_row_states.size(), "add_sink_row_states vector should have an entry for every state."
 
-    return core._eliminate_end_components_double(matrix, subsystem, possible_ecs, add_sink_row_states, add_self_loop_at_sink_states)
+    return _core._eliminate_end_components_double(matrix, subsystem, possible_ecs, add_sink_row_states, add_self_loop_at_sink_states)
 
 
 def parse_properties(properties, context=None, filters=None):
@@ -617,16 +617,16 @@ def parse_properties(properties, context=None, filters=None):
     :return: A list of properties
     """
     if context is None:
-        return core.parse_properties_without_context(properties, filters)
-    elif type(context) == core.SymbolicModelDescription:
+        return _core.parse_properties_without_context(properties, filters)
+    elif type(context) == _core.SymbolicModelDescription:
         if context.is_prism_program:
-            return core.parse_properties_for_prism_program(properties, context.as_prism_program(), filters)
+            return _core.parse_properties_for_prism_program(properties, context.as_prism_program(), filters)
         else:
-            return core.parse_properties_for_jani_program(properties, context.as_jani_model(), filters)
+            return _core.parse_properties_for_jani_program(properties, context.as_jani_model(), filters)
     elif type(context) == storage.PrismProgram:
-        return core.parse_properties_for_prism_program(properties, context, filters)
+        return _core.parse_properties_for_prism_program(properties, context, filters)
     elif type(context) == storage.JaniModel:
-        return core.parse_properties_for_jani_model(properties, context, filters)
+        return _core.parse_properties_for_jani_model(properties, context, filters)
     else:
         raise stormpy.exceptions.StormError("Unclear context. Please pass a symbolic model description")
 
@@ -640,9 +640,9 @@ def export_to_drn(model, file, options=DirectEncodingOptions()):
     :return:
     """
     if model.supports_parameters:
-        return core._export_parametric_to_drn(model, file, options)
+        return _core._export_parametric_to_drn(model, file, options)
     if model.supports_uncertainty:
-        return core._export_to_drn_interval(model, file, options)
+        return _core._export_to_drn_interval(model, file, options)
     if model.is_exact:
-        return core._export_exact_to_drn(model, file, options)
-    return core._export_to_drn(model, file, options)
+        return _core._export_exact_to_drn(model, file, options)
+    return _core._export_to_drn(model, file, options)

--- a/lib/stormpy/__init__.py
+++ b/lib/stormpy/__init__.py
@@ -1,8 +1,5 @@
 import sys
 
-if sys.version_info[0] == 2:
-    raise ImportError("Python 2.x is not supported for stormpy.")
-
 from ._config import *
 
 from . import _core

--- a/lib/stormpy/__init__.py
+++ b/lib/stormpy/__init__.py
@@ -256,7 +256,6 @@ def perform_sparse_bisimulation(model, properties, bisimulation_type, graph_pres
         return _core._perform_bisimulation(model, formulae, bisimulation_type, graph_preserving)
 
 
-
 def perform_symbolic_bisimulation(model, properties, quotient_format=stormpy.QuotientFormat.DD):
     """
     Perform bisimulation on model in symbolic representation.

--- a/lib/stormpy/dft/__init__.py
+++ b/lib/stormpy/dft/__init__.py
@@ -3,43 +3,43 @@ from stormpy import _config
 if not _config.storm_with_dft:
     raise ImportError("No support for DFTs was built in Storm.")
 
-from . import dft
-from .dft import *
+from . import _dft
+from ._dft import *
 from .modules import modules_json
 
-dft._set_up()
+_dft._set_up()
 
 
 def analyze_dft(ft, properties, symred=True, allow_modularisation=False, relevant_events=RelevantEvents(), allow_dc_for_relevant=False):
     if isinstance(ft, DFT_double):
-        return dft._analyze_dft_double(ft, properties, symred, allow_modularisation, relevant_events, allow_dc_for_relevant)
+        return _dft._analyze_dft_double(ft, properties, symred, allow_modularisation, relevant_events, allow_dc_for_relevant)
     else:
         assert isinstance(ft, DFT_ratfunc)
-        return dft._analyze_dft_ratfunc(ft, properties, symred, allow_modularisation, relevant_events, allow_dc_for_relevant)
+        return _dft._analyze_dft_ratfunc(ft, properties, symred, allow_modularisation, relevant_events, allow_dc_for_relevant)
 
 
 def build_model(ft, symmetries=DftSymmetries(), relevant_events=RelevantEvents(), allow_dc_for_relevant=False):
     if isinstance(ft, DFT_double):
-        return dft._build_model_double(ft, symmetries, relevant_events, allow_dc_for_relevant)
+        return _dft._build_model_double(ft, symmetries, relevant_events, allow_dc_for_relevant)
     else:
         assert isinstance(ft, DFT_ratfunc)
-        return dft._build_model_ratfunc(ft, symmetries, relevant_events, allow_dc_for_relevant)
+        return _dft._build_model_ratfunc(ft, symmetries, relevant_events, allow_dc_for_relevant)
 
 
 def transform_dft(ft, unique_constant_be, binary_fdeps, exponential_distributions):
     if isinstance(ft, DFT_double):
-        return dft._transform_dft_double(ft, unique_constant_be, binary_fdeps, exponential_distributions)
+        return _dft._transform_dft_double(ft, unique_constant_be, binary_fdeps, exponential_distributions)
     else:
         assert isinstance(ft, DFT_ratfunc)
-        return dft._transform_dft_ratfunc(ft, unique_constant_be, binary_fdeps, exponential_distributions)
+        return _dft._transform_dft_ratfunc(ft, unique_constant_be, binary_fdeps, exponential_distributions)
 
 
 def compute_dependency_conflicts(ft, use_smt=False, solver_timeout=0):
     if isinstance(ft, DFT_double):
-        return dft._compute_dependency_conflicts_double(ft, use_smt, solver_timeout)
+        return _dft._compute_dependency_conflicts_double(ft, use_smt, solver_timeout)
     else:
         assert isinstance(ft, DFT_ratfunc)
-        return dft._compute_dependency_conflicts_ratfunc(ft, use_smt, solver_timeout)
+        return _dft._compute_dependency_conflicts_ratfunc(ft, use_smt, solver_timeout)
 
 
 def prepare_for_analysis(ft):
@@ -49,15 +49,15 @@ def prepare_for_analysis(ft):
 
 def is_well_formed(ft, check_valid_for_analysis=True):
     if isinstance(ft, DFT_double):
-        return dft._is_well_formed_double(ft, check_valid_for_analysis)
+        return _dft._is_well_formed_double(ft, check_valid_for_analysis)
     else:
         assert isinstance(ft, DFT_ratfunc)
-        return dft._is_well_formed_ratfunc(ft, check_valid_for_analysis)
+        return _dft._is_well_formed_ratfunc(ft, check_valid_for_analysis)
 
 
 def has_potential_modeling_issues(ft):
     if isinstance(ft, DFT_double):
-        return dft._has_potential_modeling_issues_double(ft)
+        return _dft._has_potential_modeling_issues_double(ft)
     else:
         assert isinstance(ft, DFT_ratfunc)
-        return dft._has_potential_modeling_issues_ratfunc(ft)
+        return _dft._has_potential_modeling_issues_ratfunc(ft)

--- a/lib/stormpy/exceptions/__init__.py
+++ b/lib/stormpy/exceptions/__init__.py
@@ -1,11 +1,1 @@
-class StormError(Exception):
-    """
-    Base class for exceptions in Storm.
-    """
-
-    def __init__(self, message):
-        """
-        Constructor.
-        :param message: Error message.
-        """
-        self.message = "Storm: " + message
+from .storm_error import StormError

--- a/lib/stormpy/exceptions/storm_error.py
+++ b/lib/stormpy/exceptions/storm_error.py
@@ -1,0 +1,11 @@
+class StormError(Exception):
+    """
+    Base class for exceptions in Storm.
+    """
+
+    def __init__(self, message):
+        """
+        Constructor.
+        :param message: Error message.
+        """
+        self.message = "Storm: " + message

--- a/lib/stormpy/exceptions/storm_error.py
+++ b/lib/stormpy/exceptions/storm_error.py
@@ -3,9 +3,11 @@ class StormError(Exception):
     Base class for exceptions in Storm.
     """
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """
         Constructor.
+
         :param message: Error message.
+        :type message: str
         """
         self.message = "Storm: " + message

--- a/lib/stormpy/gspn/__init__.py
+++ b/lib/stormpy/gspn/__init__.py
@@ -3,5 +3,5 @@ from stormpy import _config
 if not _config.storm_with_gspn:
     raise ImportError("No support for GSPNs was built in Storm.")
 
-from . import gspn
-from .gspn import *
+from . import _gspn
+from ._gspn import *

--- a/lib/stormpy/info/__init__.py
+++ b/lib/stormpy/info/__init__.py
@@ -1,4 +1,4 @@
-from .info import *
+from ._info import *
 from . import _config
 
 

--- a/lib/stormpy/info/__init__.py
+++ b/lib/stormpy/info/__init__.py
@@ -1,28 +1,32 @@
-from . import info
 from .info import *
-
 from . import _config
 
 
-def storm_version():
+def storm_version() -> str:
     """
-    Get storm version.
+    Get Storm version.
+
     :return: Storm version
+    :rtype: str
     """
     return _config.storm_version
 
 
-def storm_exact_use_cln():
+def storm_exact_use_cln() -> bool:
     """
-    Check if exact arithmetic in Storm uses CLN.
-    :return: True if exact arithmetic uses CLN.
+    Check if exact arithmetic in Storm uses CLN or GMP.
+
+    :return: True iff exact arithmetic uses CLN.
+    :rtype: bool
     """
     return _config.storm_cln_ea
 
 
-def storm_ratfunc_use_cln():
+def storm_ratfunc_use_cln() -> bool:
     """
-    Check if rational functions in Storm use CLN.
+    Check if rational functions in Storm use CLN or GMP.
+
     :return: True iff rational functions use CLN.
+    :rtype: bool
     """
     return _config.storm_cln_rf

--- a/lib/stormpy/logic/__init__.py
+++ b/lib/stormpy/logic/__init__.py
@@ -1,2 +1,2 @@
-from . import logic
-from .logic import *
+from . import _logic
+from ._logic import *

--- a/lib/stormpy/pars/__init__.py
+++ b/lib/stormpy/pars/__init__.py
@@ -6,7 +6,7 @@ if not _config.storm_with_pars:
 from . import pars
 from .pars import *
 
-from stormpy import ModelType, StormError
+from stormpy import ModelType
 
 pars._set_up()
 
@@ -30,7 +30,7 @@ class ModelInstantiator:
         elif model.model_type == ModelType.MA:
             self._instantiator = PMaInstantiator(model)
         else:
-            raise StormError("Model type {} not supported".format(model.model_type))
+            raise stormpy.exceptions.StormError("Model type {} not supported".format(model.model_type))
 
     def instantiate(self, valuation):
         """
@@ -53,7 +53,7 @@ def simplify_model(model, formula):
     elif model.model_type == ModelType.MDP:
         simplifier = pars._SparseParametricMdpSimplifier(model)
     else:
-        raise StormError("Model type {} cannot be simplified.".format(model.model_type))
+        raise stormpy.exceptions.StormError("Model type {} cannot be simplified.".format(model.model_type))
     if not simplifier.simplify(formula):
-        raise StormError("Model could not be simplified")
+        raise stormpy.exceptions.StormError("Model could not be simplified")
     return simplifier.simplified_model, simplifier.simplified_formula

--- a/lib/stormpy/pars/__init__.py
+++ b/lib/stormpy/pars/__init__.py
@@ -3,12 +3,12 @@ from stormpy import _config
 if not _config.storm_with_pars:
     raise ImportError("No support for parametric analysis was built in Storm.")
 
-from . import pars
-from .pars import *
+from . import _pars
+from ._pars import *
 
 from stormpy import ModelType
 
-pars._set_up()
+_pars._set_up()
 
 
 class ModelInstantiator:
@@ -49,9 +49,9 @@ def simplify_model(model, formula):
     :return: Tuple of simplified model and simplified formula.
     """
     if model.model_type == ModelType.DTMC:
-        simplifier = pars._SparseParametricDtmcSimplifier(model)
+        simplifier = _pars._SparseParametricDtmcSimplifier(model)
     elif model.model_type == ModelType.MDP:
-        simplifier = pars._SparseParametricMdpSimplifier(model)
+        simplifier = _pars._SparseParametricMdpSimplifier(model)
     else:
         raise stormpy.exceptions.StormError("Model type {} cannot be simplified.".format(model.model_type))
     if not simplifier.simplify(formula):

--- a/lib/stormpy/pomdp/__init__.py
+++ b/lib/stormpy/pomdp/__init__.py
@@ -3,8 +3,8 @@ from stormpy import _config
 if not _config.storm_with_pomdp:
     raise ImportError("No support for POMDPs was built in Storm.")
 
-from . import pomdp
-from .pomdp import *
+from . import _pomdp
+from ._pomdp import *
 
 
 def make_canonic(model):
@@ -15,9 +15,9 @@ def make_canonic(model):
     """
 
     if model.supports_parameters:
-        return pomdp._make_canonic_Rf(model)
+        return _pomdp._make_canonic_Rf(model)
     else:
-        return pomdp._make_canonic_Double(model)
+        return _pomdp._make_canonic_Double(model)
 
 
 def make_simple(model, keep_state_valuations=False):
@@ -28,9 +28,9 @@ def make_simple(model, keep_state_valuations=False):
     :return:
     """
     if model.supports_parameters:
-        return pomdp._make_simple_Rf(model, keep_state_valuations)
+        return _pomdp._make_simple_Rf(model, keep_state_valuations)
     else:
-        return pomdp._make_simple_Double(model, keep_state_valuations)
+        return _pomdp._make_simple_Double(model, keep_state_valuations)
 
 
 def unfold_memory(model, memory, add_memory_labels=False, keep_state_valuations=False):
@@ -42,16 +42,16 @@ def unfold_memory(model, memory, add_memory_labels=False, keep_state_valuations=
     :return: A pomdp that contains states from the product of the original POMDP and the FSC Memory
     """
     if model.supports_parameters:
-        return pomdp._unfold_memory_Rf(model, memory, add_memory_labels, keep_state_valuations)
+        return _pomdp._unfold_memory_Rf(model, memory, add_memory_labels, keep_state_valuations)
     else:
-        return pomdp._unfold_memory_Double(model, memory, add_memory_labels, keep_state_valuations)
+        return _pomdp._unfold_memory_Double(model, memory, add_memory_labels, keep_state_valuations)
 
 
 def apply_unknown_fsc(model, mode):
     if model.supports_parameters:
-        return pomdp._apply_unknown_fsc_Rf(model, mode)
+        return _pomdp._apply_unknown_fsc_Rf(model, mode)
     else:
-        return pomdp._apply_unknown_fsc_Double(model, mode)
+        return _pomdp._apply_unknown_fsc_Double(model, mode)
 
 
 def create_nondeterminstic_belief_tracker(model, reduction_timeout, track_timeout):
@@ -65,12 +65,12 @@ def create_nondeterminstic_belief_tracker(model, reduction_timeout, track_timeou
         opts = NondeterministicBeliefTrackerExactSparseOptions()
         opts.reduction_timeout = reduction_timeout
         opts.track_timeout = track_timeout
-        return pomdp.NondeterministicBeliefTrackerExactSparse(model, opts)
+        return _pomdp.NondeterministicBeliefTrackerExactSparse(model, opts)
     else:
         opts = NondeterministicBeliefTrackerDoubleSparseOptions()
         opts.reduction_timeout = reduction_timeout
         opts.track_timeout = track_timeout
-        return pomdp.NondeterministicBeliefTrackerDoubleSparse(model, opts)
+        return _pomdp.NondeterministicBeliefTrackerDoubleSparse(model, opts)
 
 
 def create_observation_trace_unfolder(model, risk_assessment, expr_manager):
@@ -82,6 +82,6 @@ def create_observation_trace_unfolder(model, risk_assessment, expr_manager):
     :return:
     """
     if model.is_exact:
-        return pomdp.ObservationTraceUnfolderExact(model, risk_assessment, expr_manager)
+        return _pomdp.ObservationTraceUnfolderExact(model, risk_assessment, expr_manager)
     else:
-        return pomdp.ObservationTraceUnfolderDouble(model, risk_assessment, expr_manager)
+        return _pomdp.ObservationTraceUnfolderDouble(model, risk_assessment, expr_manager)

--- a/lib/stormpy/pycarl/__init__.py
+++ b/lib/stormpy/pycarl/__init__.py
@@ -1,8 +1,5 @@
 import sys
 
-if sys.version_info[0] == 2:
-    raise ImportError("Python 2.x is not supported for pycarl.")
-
 from . import _pycarl_core
 from ._pycarl_core import *
 from . import infinity

--- a/lib/stormpy/pycarl/__init__.py
+++ b/lib/stormpy/pycarl/__init__.py
@@ -3,8 +3,8 @@ import sys
 if sys.version_info[0] == 2:
     raise ImportError("Python 2.x is not supported for pycarl.")
 
-from . import pycarl_core
-from .pycarl_core import *
+from . import _pycarl_core
+from ._pycarl_core import *
 from . import infinity
 from stormpy.pycarl import _config
 

--- a/lib/stormpy/pycarl/__init__.py
+++ b/lib/stormpy/pycarl/__init__.py
@@ -1,5 +1,3 @@
-import sys
-
 from . import _pycarl_core
 from ._pycarl_core import *
 from . import infinity

--- a/lib/stormpy/pycarl/cln/__init__.py
+++ b/lib/stormpy/pycarl/cln/__init__.py
@@ -2,34 +2,34 @@ from stormpy.pycarl import _config
 
 if not _config.CARL_WITH_CLN:
     raise ImportError("CLN is not available in the configured carl library! Did you configure carl with -DUSE_CLN_NUMBERS=ON?")
-from . import cln
-from .cln import *
+from . import _cln
+from ._cln import *
 
 
 def numerator(x):
-    if type(x) == cln.RationalFunction or type(x) == cln.Rational or type(x) == cln.FactorizedRationalFunction:
+    if type(x) == _cln.RationalFunction or type(x) == _cln.Rational or type(x) == _cln.FactorizedRationalFunction:
         return x.numerator
     else:
         return x
 
 
 def denominator(x):
-    if type(x) == cln.RationalFunction or type(x) == cln.Rational or type(x) == cln.FactorizedRationalFunction:
+    if type(x) == _cln.RationalFunction or type(x) == _cln.Rational or type(x) == _cln.FactorizedRationalFunction:
         return x.denominator
     else:
         return 1
 
 
 def expand(x):
-    if type(x) == cln.FactorizedRationalFunction:
+    if type(x) == _cln.FactorizedRationalFunction:
         return x.rational_function()
-    if type(x) == cln.FactorizedPolynomial:
+    if type(x) == _cln.FactorizedPolynomial:
         return x.polynomial()
     return x
 
 
-factorization_cache = cln._FactorizationCache()
+factorization_cache = _cln._FactorizationCache()
 
 
 def create_factorized_polynomial(polynomial):
-    return cln.FactorizedPolynomial(polynomial, factorization_cache)
+    return _cln.FactorizedPolynomial(polynomial, factorization_cache)

--- a/lib/stormpy/pycarl/cln/formula/__init__.py
+++ b/lib/stormpy/pycarl/cln/formula/__init__.py
@@ -1,2 +1,2 @@
-from . import formula
-from .formula import *
+from . import _formula
+from ._formula import *

--- a/lib/stormpy/pycarl/cln/parse/__init__.py
+++ b/lib/stormpy/pycarl/cln/parse/__init__.py
@@ -3,5 +3,5 @@ from stormpy.pycarl import _config
 if not _config.CARL_WITH_PARSER:
     raise ImportError("Parser is not available!")
 
-from . import parse
-from .parse import *
+from . import _parse
+from ._parse import *

--- a/lib/stormpy/pycarl/formula/__init__.py
+++ b/lib/stormpy/pycarl/formula/__init__.py
@@ -1,2 +1,2 @@
 from stormpy.pycarl.formula import *
-from .formula import *
+from ._formula import *

--- a/lib/stormpy/pycarl/gmp/__init__.py
+++ b/lib/stormpy/pycarl/gmp/__init__.py
@@ -1,31 +1,31 @@
-from . import gmp
-from .gmp import *
+from . import _gmp
+from ._gmp import *
 
 
 def numerator(x):
-    if type(x) == gmp.RationalFunction or type(x) == gmp.Rational or type(x) == gmp.FactorizedRationalFunction:
+    if type(x) == _gmp.RationalFunction or type(x) == _gmp.Rational or type(x) == _gmp.FactorizedRationalFunction:
         return x.numerator
     else:
         return x
 
 
 def denominator(x):
-    if type(x) == gmp.RationalFunction or type(x) == gmp.Rational or type(x) == gmp.FactorizedRationalFunction:
+    if type(x) == _gmp.RationalFunction or type(x) == _gmp.Rational or type(x) == _gmp.FactorizedRationalFunction:
         return x.denominator
     else:
         return 1
 
 
 def expand(x):
-    if type(x) == gmp.FactorizedRationalFunction:
+    if type(x) == _gmp.FactorizedRationalFunction:
         return x.rational_function()
-    if type(x) == gmp.FactorizedPolynomial:
+    if type(x) == _gmp.FactorizedPolynomial:
         return x.polynomial()
     return x
 
 
-factorization_cache = gmp._FactorizationCache()
+factorization_cache = _gmp._FactorizationCache()
 
 
 def create_factorized_polynomial(polynomial):
-    return gmp.FactorizedPolynomial(polynomial, factorization_cache)
+    return _gmp.FactorizedPolynomial(polynomial, factorization_cache)

--- a/lib/stormpy/pycarl/gmp/formula/__init__.py
+++ b/lib/stormpy/pycarl/gmp/formula/__init__.py
@@ -1,2 +1,2 @@
-from . import formula
-from .formula import *
+from . import _formula
+from ._formula import *

--- a/lib/stormpy/pycarl/gmp/parse/__init__.py
+++ b/lib/stormpy/pycarl/gmp/parse/__init__.py
@@ -3,5 +3,5 @@ from stormpy.pycarl import _config
 if not _config.CARL_WITH_PARSER:
     raise ImportError("Parser is not available!")
 
-from . import parse
-from .parse import *
+from . import _parse
+from ._parse import *

--- a/lib/stormpy/pycarl/parse/__init__.py
+++ b/lib/stormpy/pycarl/parse/__init__.py
@@ -3,8 +3,8 @@ from stormpy.pycarl import _config
 if not _config.CARL_WITH_PARSER:
     raise ImportError("Parser is not available in the configured carl library! Did you configure carl with '-DBUILD_ADDONS=ON -DBUILD_ADDON_PARSER=ON'?")
 
-from . import parse
-from .parse import *
+from . import _parse
+from ._parse import *
 
 
 class ParserError(Exception):
@@ -24,27 +24,27 @@ def deserialize(input, package):
     """
     error = None
     try:
-        res = package.parse.parse._deserialize(input)
+        res = package.parse._parse._deserialize(input)
     except RuntimeError as e:
         error = str(e)
     # ugly save and rethrow yields improved error messages in pytest.
     if error:
         raise ParserError(error + " when parsing '" + input + "'")
     res_type = res.get_type()
-    if res_type == parse._ParserReturnType.Rational:
+    if res_type == _parse._ParserReturnType.Rational:
         return res.as_rational()
-    elif res_type == parse._ParserReturnType.Variable:
+    elif res_type == _parse._ParserReturnType.Variable:
         return res.as_variable()
-    elif res_type == parse._ParserReturnType.Monomial:
+    elif res_type == _parse._ParserReturnType.Monomial:
         return res.as_monomial()
-    elif res_type == parse._ParserReturnType.Term:
+    elif res_type == _parse._ParserReturnType.Term:
         return res.as_term()
-    elif res_type == parse._ParserReturnType.Polynomial:
+    elif res_type == _parse._ParserReturnType.Polynomial:
         return res.as_polynomial()
-    elif res_type == parse._ParserReturnType.RationalFunction:
+    elif res_type == _parse._ParserReturnType.RationalFunction:
         return res.as_rational_function()
-    elif res_type == parse._ParserReturnType.Constraint:
+    elif res_type == _parse._ParserReturnType.Constraint:
         return res.as_constraint()
-    elif res_type == parse._ParserReturnType.Formula:
+    elif res_type == _parse._ParserReturnType.Formula:
         return res.as_formula()
     assert False, "Internal error."

--- a/lib/stormpy/simulator.py
+++ b/lib/stormpy/simulator.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-import stormpy.core
+import stormpy._core
 
 
 class SimulatorObservationMode(Enum):
@@ -105,9 +105,9 @@ class SparseSimulator(Simulator):
         super().__init__(seed)
         self._model = model
         if self._model.is_exact:
-            self._engine = stormpy.core._DiscreteTimeSparseModelSimulatorExact(model)
+            self._engine = stormpy._core._DiscreteTimeSparseModelSimulatorExact(model)
         else:
-            self._engine = stormpy.core._DiscreteTimeSparseModelSimulatorDouble(model)
+            self._engine = stormpy._core._DiscreteTimeSparseModelSimulatorDouble(model)
         if seed is not None:
             self._engine.set_seed(seed)
         self._state_valuations = None
@@ -234,7 +234,7 @@ class PrismSimulator(Simulator):
         super().__init__(seed)
         self._program = program
         # TODO support exact arithmetic here
-        self._engine = stormpy.core._DiscreteTimePrismProgramSimulatorDouble(program, options)
+        self._engine = stormpy._core._DiscreteTimePrismProgramSimulatorDouble(program, options)
         if seed is not None:
             self._engine.set_seed(seed)
         self.set_full_observability(self._program.model_type != stormpy.storage.PrismModelType.POMDP)

--- a/lib/stormpy/simulator.py
+++ b/lib/stormpy/simulator.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 import stormpy._core
+import stormpy.storage._storage
 
 
 class SimulatorObservationMode(Enum):
@@ -344,7 +345,7 @@ def create_simulator(
     :param options: BuilderOptions that can be passed to the simulator (currently only for symbolic simulators)
     :return: A simulator that can simulate on top of this model
     """
-    if isinstance(model, stormpy.storage._ModelBase):
+    if isinstance(model, stormpy.storage._storage._ModelBase):
         if model.is_sparse_model:
             return SparseSimulator(model, seed)
     elif isinstance(model, stormpy.storage.PrismProgram):

--- a/lib/stormpy/storage/__init__.py
+++ b/lib/stormpy/storage/__init__.py
@@ -13,7 +13,7 @@ def build_sparse_matrix(array, row_group_indices=[]):
     :param List[double] row_group_indices: List containing the starting row of each row group in ascending order.
     :return: Sparse matrix.
     """
-    return _build_sparse_matrix(storage.SparseMatrixBuilder, array, row_group_indices=row_group_indices)
+    return _build_sparse_matrix(_storage.SparseMatrixBuilder, array, row_group_indices=row_group_indices)
 
 
 def build_parametric_sparse_matrix(array, row_group_indices=[]):
@@ -25,7 +25,7 @@ def build_parametric_sparse_matrix(array, row_group_indices=[]):
     :param List[double] row_group_indices: List containing the starting row of each row group in ascending order.
     :return: Parametric sparse matrix.
     """
-    return _build_sparse_matrix(storage.ParametricSparseMatrixBuilder, array, row_group_indices=row_group_indices)
+    return _build_sparse_matrix(_storage.ParametricSparseMatrixBuilder, array, row_group_indices=row_group_indices)
 
 
 def _build_sparse_matrix(builder_class, array, row_group_indices=[]):

--- a/lib/stormpy/storage/__init__.py
+++ b/lib/stormpy/storage/__init__.py
@@ -78,7 +78,7 @@ def get_maximal_end_components(model):
 
 
 # Extend class StateValuation
-def get_value(self, state, var):
+def _get_value(self, state, var):
     """
     Get the value of the given variable at the given state.
     :param state: State.
@@ -95,7 +95,7 @@ def get_value(self, state, var):
         raise ValueError(f"Variable {var} has unsupported type")
 
 
-def get_values_states(self, var):
+def _get_values_states(self, var):
     """
     Get the value of the given variable of all states.
     :param var: Variable.
@@ -111,61 +111,61 @@ def get_values_states(self, var):
         raise ValueError(f"Variable {var} has unsupported type")
 
 
-StateValuation.get_value = get_value
-StateValuation.get_values_states = get_values_states
+StateValuation.get_value = _get_value
+StateValuation.get_values_states = _get_values_states
 
 
 # Deprecated functions
 @deprecated("Use general method 'get_value' instead.")
-def get_boolean_value(self, state, var):
+def _get_boolean_value(self, state, var):
     return self._get_boolean_value(state, var)
 
 
-StateValuation.get_boolean_value = get_boolean_value
+StateValuation.get_boolean_value = _get_boolean_value
 
 
 @deprecated("Use general method 'get_value' instead.")
-def get_integer_value(self, state, var):
+def _get_integer_value(self, state, var):
     return self._get_integer_value(state, var)
 
 
-StateValuation.get_integer_value = get_integer_value
+StateValuation.get_integer_value = _get_integer_value
 
 
 @deprecated("Use general method 'get_value' instead.")
-def get_rational_value(self, state, var):
+def _get_rational_value(self, state, var):
     return self._get_rational_value(state, var)
 
 
-StateValuation.get_rational_value = get_rational_value
+StateValuation.get_rational_value = _get_rational_value
 
 
 @deprecated("Use general method 'get_values_states' instead.")
-def get_boolean_values_states(self, var):
+def _get_boolean_values_states(self, var):
     return self._get_boolean_values_states(var)
 
 
-StateValuation.get_boolean_values_states = get_boolean_values_states
+StateValuation.get_boolean_values_states = _get_boolean_values_states
 
 
 @deprecated("Use general method 'get_values_states' instead.")
-def get_integer_values_states(self, var):
+def _get_integer_values_states(self, var):
     return self._get_integer_values_states(var)
 
 
-StateValuation.get_integer_values_states = get_integer_values_states
+StateValuation.get_integer_values_states = _get_integer_values_states
 
 
 @deprecated("Use general method 'get_values_states' instead.")
-def get_rational_values_states(self, var):
+def _get_rational_values_states(self, var):
     return self._get_rational_values_states(var)
 
 
-StateValuation.get_rational_values_states = get_rational_values_states
+StateValuation.get_rational_values_states = _get_rational_values_states
 
 
 # Extend class SimpleValuation
-def get_value(self, var):
+def _get_value(self, var):
     """
     Get the value of the given variable.
     :param var: Variable.
@@ -181,21 +181,21 @@ def get_value(self, var):
         raise ValueError(f"Variable {var} has unsupported type")
 
 
-SimpleValuation.get_value = get_value
+SimpleValuation.get_value = _get_value
 
 
 # Deprecated functions
 @deprecated("Use general method 'get_value' instead.")
-def get_boolean_value(self, var):
+def _get_boolean_value(self, var):
     return self._get_boolean_value(var)
 
 
-SimpleValuation.get_boolean_value = get_boolean_value
+SimpleValuation.get_boolean_value = _get_boolean_value
 
 
 @deprecated("Use general method 'get_value' instead.")
-def get_integer_value(self, var):
+def _get_integer_value(self, var):
     return self._get_integer_value(var)
 
 
-SimpleValuation.get_integer_value = get_integer_value
+SimpleValuation.get_integer_value = _get_integer_value

--- a/lib/stormpy/storage/__init__.py
+++ b/lib/stormpy/storage/__init__.py
@@ -1,7 +1,7 @@
 import stormpy.utility
 from . import _storage
 from ._storage import *
-from deprecated import deprecated
+from deprecated.sphinx import deprecated
 
 
 def build_sparse_matrix(array, row_group_indices=[]):
@@ -116,7 +116,7 @@ StateValuation.get_values_states = _get_values_states
 
 
 # Deprecated functions
-@deprecated("Use general method 'get_value' instead.")
+@deprecated("Use general method 'get_value' instead.", version="1.10.0")
 def _get_boolean_value(self, state, var):
     return self._get_boolean_value(state, var)
 
@@ -124,7 +124,7 @@ def _get_boolean_value(self, state, var):
 StateValuation.get_boolean_value = _get_boolean_value
 
 
-@deprecated("Use general method 'get_value' instead.")
+@deprecated("Use general method 'get_value' instead.", version="1.10.0")
 def _get_integer_value(self, state, var):
     return self._get_integer_value(state, var)
 
@@ -132,7 +132,7 @@ def _get_integer_value(self, state, var):
 StateValuation.get_integer_value = _get_integer_value
 
 
-@deprecated("Use general method 'get_value' instead.")
+@deprecated("Use general method 'get_value' instead.", version="1.10.0")
 def _get_rational_value(self, state, var):
     return self._get_rational_value(state, var)
 
@@ -140,7 +140,7 @@ def _get_rational_value(self, state, var):
 StateValuation.get_rational_value = _get_rational_value
 
 
-@deprecated("Use general method 'get_values_states' instead.")
+@deprecated("Use general method 'get_values_states' instead.", version="1.10.0")
 def _get_boolean_values_states(self, var):
     return self._get_boolean_values_states(var)
 
@@ -148,7 +148,7 @@ def _get_boolean_values_states(self, var):
 StateValuation.get_boolean_values_states = _get_boolean_values_states
 
 
-@deprecated("Use general method 'get_values_states' instead.")
+@deprecated("Use general method 'get_values_states' instead.", version="1.10.0")
 def _get_integer_values_states(self, var):
     return self._get_integer_values_states(var)
 
@@ -156,7 +156,7 @@ def _get_integer_values_states(self, var):
 StateValuation.get_integer_values_states = _get_integer_values_states
 
 
-@deprecated("Use general method 'get_values_states' instead.")
+@deprecated("Use general method 'get_values_states' instead.", version="1.10.0")
 def _get_rational_values_states(self, var):
     return self._get_rational_values_states(var)
 
@@ -185,7 +185,7 @@ SimpleValuation.get_value = _get_value
 
 
 # Deprecated functions
-@deprecated("Use general method 'get_value' instead.")
+@deprecated("Use general method 'get_value' instead.", version="1.10.0")
 def _get_boolean_value(self, var):
     return self._get_boolean_value(var)
 
@@ -193,7 +193,7 @@ def _get_boolean_value(self, var):
 SimpleValuation.get_boolean_value = _get_boolean_value
 
 
-@deprecated("Use general method 'get_value' instead.")
+@deprecated("Use general method 'get_value' instead.", version="1.10.0")
 def _get_integer_value(self, var):
     return self._get_integer_value(var)
 

--- a/lib/stormpy/storage/__init__.py
+++ b/lib/stormpy/storage/__init__.py
@@ -1,6 +1,6 @@
 import stormpy.utility
-from . import storage
-from .storage import *
+from . import _storage
+from ._storage import *
 from deprecated import deprecated
 
 

--- a/lib/stormpy/utility/__init__.py
+++ b/lib/stormpy/utility/__init__.py
@@ -1,12 +1,12 @@
-from . import utility
-from .utility import *
+from . import _utility
+from ._utility import *
 
 # Extend JSON container for simplified access
-utility.JsonContainerDouble.__eq__ = lambda s, o: str(s) == str(o)
-utility.JsonContainerDouble.__int__ = lambda s: int(str(s))
-utility.JsonContainerDouble.__hash__ = lambda s: str(s).__hash__()
+_utility.JsonContainerDouble.__eq__ = lambda s, o: str(s) == str(o)
+_utility.JsonContainerDouble.__int__ = lambda s: int(str(s))
+_utility.JsonContainerDouble.__hash__ = lambda s: str(s).__hash__()
 
 
-utility.JsonContainerRational.__eq__ = lambda s, o: str(s) == str(o)
-utility.JsonContainerRational.__int__ = lambda s: int(str(s))
-utility.JsonContainerRational.__hash__ = lambda s: str(s).__hash__()
+_utility.JsonContainerRational.__eq__ = lambda s, o: str(s) == str(o)
+_utility.JsonContainerRational.__int__ = lambda s: int(str(s))
+_utility.JsonContainerRational.__hash__ = lambda s: str(s).__hash__()

--- a/src/mod_core.cpp
+++ b/src/mod_core.cpp
@@ -11,7 +11,7 @@
 #include "core/transformation.h"
 #include "core/simulator.h"
 
-PYBIND11_MODULE(core, m) {
+PYBIND11_MODULE(_core, m) {
     m.doc() = "core";
 
 #ifdef STORMPY_DISABLE_SIGNATURE_DOC

--- a/src/mod_dft.cpp
+++ b/src/mod_dft.cpp
@@ -9,7 +9,7 @@
 #include "dft/simulator.h"
 #include "dft/transformations.h"
 
-PYBIND11_MODULE(dft, m) {
+PYBIND11_MODULE(_dft, m) {
     m.doc() = "Functionality for DFT analysis";
 
 #ifdef STORMPY_DISABLE_SIGNATURE_DOC

--- a/src/mod_gspn.cpp
+++ b/src/mod_gspn.cpp
@@ -3,7 +3,7 @@
 #include "gspn/gspn.h"
 #include "gspn/gspn_io.h"
 
-PYBIND11_MODULE(gspn, m) {
+PYBIND11_MODULE(_gspn, m) {
     m.doc() = "Support for GSPNs";
 
 #ifdef STORMPY_DISABLE_SIGNATURE_DOC

--- a/src/mod_info.cpp
+++ b/src/mod_info.cpp
@@ -11,7 +11,7 @@ PYBIND11_MODULE(info, m) {
 
     py::class_<storm::StormVersion>(m, "Version", "Version information for Storm")
         // static properties are still called with self as argument (which we ignore), see
-        // https://pybind11.readthedocs.io/en/master/advanced/classes.html#static-properties
+        // https://pybind11.readthedocs.io/en/stable/advanced/classes.html#static-properties
         .def_property_readonly_static("major", [](py::object /* self */){ return storm::StormVersion::versionMajor; }, "Storm major version.")
         .def_property_readonly_static("minor", [](py::object /* self */){ return storm::StormVersion::versionMinor; }, "Storm minor version.")
         .def_property_readonly_static("patch", [](py::object /* self */){ return storm::StormVersion::versionPatch; }, "Storm patch version.")

--- a/src/mod_info.cpp
+++ b/src/mod_info.cpp
@@ -1,7 +1,7 @@
 #include "common.h"
 #include "storm-version-info/storm-version.h"
 
-PYBIND11_MODULE(info, m) {
+PYBIND11_MODULE(_info, m) {
     m.doc() = "Storm information";
 
 #ifdef STORMPY_DISABLE_SIGNATURE_DOC

--- a/src/mod_logic.cpp
+++ b/src/mod_logic.cpp
@@ -2,7 +2,7 @@
 
 #include "logic/formulae.h"
 
-PYBIND11_MODULE(logic, m) {
+PYBIND11_MODULE(_logic, m) {
     m.doc() = "Logic module for Storm";
 
 #ifdef STORMPY_DISABLE_SIGNATURE_DOC

--- a/src/mod_pars.cpp
+++ b/src/mod_pars.cpp
@@ -4,7 +4,7 @@
 #include "pars/pla.h"
 #include "pars/model_instantiator.h"
 
-PYBIND11_MODULE(pars, m) {
+PYBIND11_MODULE(_pars, m) {
     m.doc() = "Functionality for parametric analysis";
 
 #ifdef STORMPY_DISABLE_SIGNATURE_DOC

--- a/src/mod_pomdp.cpp
+++ b/src/mod_pomdp.cpp
@@ -8,7 +8,7 @@
 #include "pomdp/quantitative_analysis.h"
 #include <storm/adapters/RationalFunctionAdapter.h>
 
-PYBIND11_MODULE(pomdp, m) {
+PYBIND11_MODULE(_pomdp, m) {
     m.doc() = "Functionality for POMDP analysis";
 
 #ifdef STORMPY_DISABLE_SIGNATURE_DOC

--- a/src/mod_storage.cpp
+++ b/src/mod_storage.cpp
@@ -19,7 +19,7 @@
 
 #include "storm/storage/dd/DdType.h"
 
-PYBIND11_MODULE(storage, m) {
+PYBIND11_MODULE(_storage, m) {
     m.doc() = "Data structures in Storm";
 
 #ifdef STORMPY_DISABLE_SIGNATURE_DOC

--- a/src/mod_utility.cpp
+++ b/src/mod_utility.cpp
@@ -6,7 +6,7 @@
 #include "utility/json.h"
 #include "storm/adapters/RationalNumberAdapter.h"
 
-PYBIND11_MODULE(utility, m) {
+PYBIND11_MODULE(_utility, m) {
     m.doc() = "Utilities for Storm";
 
 #ifdef STORMPY_DISABLE_SIGNATURE_DOC

--- a/src/pycarl/mod_cln.cpp
+++ b/src/pycarl/mod_cln.cpp
@@ -11,7 +11,7 @@
 #include "typed_core/factorizedrationalfunction.h"
 #include "typed_core/interval.h"
 
-PYBIND11_MODULE(cln, m) {
+PYBIND11_MODULE(_cln, m) {
     m.attr("__name__") = "stormpy.pycarl.cln";
 
     m.doc() = "pycarl core cln-typed data and functions";

--- a/src/pycarl/mod_core.cpp
+++ b/src/pycarl/mod_core.cpp
@@ -5,7 +5,7 @@
 #include "core/bound_type.h"
 #include "typed_core/interval.h"
 
-PYBIND11_MODULE(pycarl_core, m) {
+PYBIND11_MODULE(_pycarl_core, m) {
     m.doc() = "pycarl core untyped functions";
 
     define_variabletype(m);

--- a/src/pycarl/mod_formula.cpp
+++ b/src/pycarl/mod_formula.cpp
@@ -4,7 +4,7 @@
 #include "formula/formula_type.h"
 #include "formula/relation.h"
 
-PYBIND11_MODULE(formula, m) {
+PYBIND11_MODULE(_formula, m) {
     m.attr("__name__") = "stormpy.pycarl.formula";
 	m.doc() = "pycarl formula untyped functions";
 

--- a/src/pycarl/mod_gmp.cpp
+++ b/src/pycarl/mod_gmp.cpp
@@ -11,7 +11,7 @@
 #include "typed_core/factorizedrationalfunction.h"
 #include "typed_core/interval.h"
 
-PYBIND11_MODULE(gmp, m) {
+PYBIND11_MODULE(_gmp, m) {
     m.attr("__name__") = "stormpy.pycarl.gmp";
     m.doc() = "pycarl core gmp-typed data and functions";
 

--- a/src/pycarl/mod_parse.cpp
+++ b/src/pycarl/mod_parse.cpp
@@ -8,7 +8,7 @@
 /**
  * The actual module definition
  */
-PYBIND11_MODULE(parse, m) {
+PYBIND11_MODULE(_parse, m) {
     m.attr("__name__") = "stormpy.pycarl.parse";
     m.doc() = "pycarl parsing functions";
 

--- a/src/pycarl/mod_typed_formula.cpp
+++ b/src/pycarl/mod_typed_formula.cpp
@@ -4,7 +4,7 @@
 #include "typed_formula/constraint.h"
 #include "typed_formula/formula.h"
 
-PYBIND11_MODULE(formula, m) {
+PYBIND11_MODULE(_formula, m) {
     m.attr("__name__") = "stormpy.pycarl.formula";
 	m.doc() = "pycarl formula typed functions";
 

--- a/src/pycarl/mod_typed_parse.cpp
+++ b/src/pycarl/mod_typed_parse.cpp
@@ -9,7 +9,7 @@
 /**
  * The actual module definition
  */
-PYBIND11_MODULE(parse, m) {
+PYBIND11_MODULE(_parse, m) {
     m.attr("__name__") = "stormpy.pycarl.parse";
     m.doc() = "pycarl parse typed functions";
 

--- a/tests/core/test_modelchecking.py
+++ b/tests/core/test_modelchecking.py
@@ -141,7 +141,7 @@ class TestModelChecking:
         (prob0, prob1) = stormpy.compute_prob01_states(model, phiStates, psiStates)
         assert prob0.number_of_set_bits() == 9
         assert prob1.number_of_set_bits() == 1
-        labelprop = stormpy.core.Property("cora", formulaPsi.raw_formula)
+        labelprop = stormpy.Property("cora", formulaPsi.raw_formula)
         result = stormpy.model_checking(model, labelprop)
         assert result.get_truth_values().number_of_set_bits() == 1
 

--- a/tests/info/test_info.py
+++ b/tests/info/test_info.py
@@ -1,4 +1,3 @@
-import stormpy
 import stormpy.info
 
 

--- a/tests/logic/test_formulas.py
+++ b/tests/logic/test_formulas.py
@@ -69,7 +69,7 @@ class TestFormulas:
         assert type(pathform) == stormpy.logic.EventuallyFormula
         labelform = pathform.subformula
         assert type(labelform) == stormpy.logic.AtomicLabelFormula
-        prop = stormpy.core.Property("label-formula", labelform)
+        prop = stormpy.Property("label-formula", labelform)
         assert prop.raw_formula == labelform
 
     def test_game_formula(self):

--- a/tests/storage/test_model.py
+++ b/tests/storage/test_model.py
@@ -68,7 +68,7 @@ class TestSparseModel:
         jani_model, properties = stormpy.parse_jani_model(get_example_path("dtmc", "brp.jani"))
         assert jani_model.has_undefined_constants
         assert not jani_model.undefined_constants_are_graph_preserving
-        with pytest.raises(stormpy.StormError):
+        with pytest.raises(stormpy.exceptions.StormError):
             model = stormpy.build_model(jani_model)
 
     def test_build_instantiated_dtmc_prism(self):


### PR DESCRIPTION
- Add an underscore suffix to all pybind libraries, e.g. `_storage` instead of `storage`. This helps distinguishing between the Python module `storage` and the pybind library `_storage`. Some adaptions were required but nothing should change on the outside.
- Added new module `stormpy.exceptions` and added type information to docstring
- Revised documentation for `stormpy.info`. I tried making the functions `storm_version()`, etc properties, but this lead to issues because the property decorator is aimed at classes and not modules.
- Generate API documentation for `stormpy.pomdp`
- Use sphinx decorator for deprecation. Deprecations now require a version and I opted to use the last version `1.10.0`. Technically the deprecation was only introduced afterwards, but otherwise we need to reference a future version without knowing what version number we will actually have.
- Our Sphinx documentation generates documentation also for imported members (to include the pybind libraries). I needed to explicitly exclude the `deprecated` import as it would occur in the documentation otherwise. We have to keep an eye on future imports which we also might need to exclude.

