### PR TITLE
Use latest Sphinx version, reverts #214

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ plot = [
     "scipy",
 ]
 doc = [
-    "Sphinx<8.2.0",
+    "Sphinx>=8.2.2",
     "sphinx-nefertiti",
     "sphinx-copybutton",
     "nbsphinx",


### PR DESCRIPTION
Reverts workaround introduced in #214.
Sphinx 8.2.2 is [fixed](https://github.com/spatialaudio/nbsphinx/issues/825#issuecomment-2692944098).