### PR TITLE
Reusable workflow for updating Storm version

### DIFF
--- a/.github/workflows/update_storm.yml
+++ b/.github/workflows/update_storm.yml
@@ -1,0 +1,45 @@
+name: Update Storm version
+
+on:
+  # needed to reuse the workflow from another one
+  workflow_call:
+    inputs:
+      storm_version:
+        description: 'Storm version'
+        required: true
+        type: string
+        default: 'x.y.z'
+    secrets:
+      # needs permissions 'pull-request' and 'workflows'
+      personal_access_token:
+        required: true
+
+jobs:
+  update_stormpy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git clone
+        uses: actions/checkout@v5
+        with:
+          repository: moves-rwth/stormpy
+      - name: Update Storm version
+        run: |
+          # Update STORM_MIN_VERSION
+          sed -i -E 's/STORM_MIN_VERSION "(.+)"/STORM_MIN_VERSION "${{ inputs.storm_version }}"/' CMakeLists.txt
+      - name: Commit update
+        run: |
+          git diff
+          git config user.name 'Stormchecker bot'
+          git config user.email 'dev@stormchecker.org'
+          git commit -am "Use Storm ${{ inputs.storm_version }}"
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.personal_access_token }}
+          branch: ci/update-storm
+          delete-branch: true
+          title: 'Update Storm ${{ inputs.storm_version }}'
+          body: |
+            Auto-generated pull request triggered by a new Storm version.
+            - Manually close and reopen this PR to trigger the CI.


### PR DESCRIPTION
Workflow can be externally triggered (from Storm) and then updates the `STORM_MIN_VERSION` in `CMakeLists.txt`. Afterwards a PR is openend.

Requires a personal access token with permissions for 'pull-request' and 'workflows'
