### PR TITLE
Build wheels on Linux ARM

### DIFF
--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
-        os: [ linux-intel, macos-intel, macos-arm ]
+        os: [ linux-intel, linux-arm, macos-intel, macos-arm ]
         include:
           # Set defaults
           - archs: auto
@@ -34,6 +34,9 @@ jobs:
           - os: linux-intel
             runs-on: ubuntu-latest
             archs: x86_64
+          - os: linux-arm
+            runs-on: ubuntu-24.04-arm
+            archs: aarch64
           - os: macos-intel
             runs-on: macos-13 # macos-13 was the last x86_64 runner
             xcode: 14.3
@@ -76,21 +79,33 @@ jobs:
 
 
   test_wheels_linux:
-    name: Test wheel on ${{ matrix.distro }}
+    name: Test wheel on ${{ matrix.distro }} and ${{ matrix.arch.name }}
     needs: [build_wheels]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch.runner }}
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - {name: linux-intel,
+             runner: ubuntu-latest
+          }
+          - {name: linux-arm,
+             runner: ubuntu-24.04-arm
+          }
         distro:
-          - ubuntu:24.04
-          - debian:13
+          - ubuntu:latest
+          - ubuntu:rolling
+          - debian:latest
           - fedora:latest
           - archlinux:latest
+        exclude:
+          - arch: {name: linux-arm, runner: ubuntu-24.04-arm}
+            distro: archlinux:latest
+
     steps:
       - uses: actions/download-artifact@v5
         with:
-          pattern: stormpy-wheels-linux-intel
+          pattern: stormpy-wheels-${{ matrix.arch.name }}
           path: dist
           merge-multiple: true
       - name: Checkout test files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ input = "lib/stormpy/_version.py"
 
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux_2_34"
+manylinux-aarch64-image = "manylinux_2_34"
 skip = "*musllinux*"
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
Support Linux ARM as well.

Requires https://github.com/moves-rwth/carl-storm/pull/94

Seems to work in general, but there are issues with the symbolic engine on ARM, see [this CI test run](https://github.com/volkm/stormpy/actions/runs/18040660533/job/51345290314).