### PR TITLE
Fixed pybind and scikit-build-core versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core", "pybind11"]
+requires = ["scikit-build-core==0.11.6", "pybind11==3.0.1"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
Following discussion in https://github.com/moves-rwth/stormpy/issues/251 we fix the versions of pybind and also of scikit-build-core.