### PR TITLE
Use Storm 1.11.1 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ function(check_hint NAME DIR_FOUND HINT_DIR FOUND_VERSION)
 endfunction(check_hint)
 
 if(ALLOW_STORM_SYSTEM)
-    set(STORM_MIN_VERSION "1.11.1")
+    set(STORM_MIN_VERSION "1.11.0")
     if (ALLOW_STORM_FETCH)
         find_package(storm HINTS ${STORM_DIR_HINT}) # NOT REQUIRED, can be fetched.
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ function(check_hint NAME DIR_FOUND HINT_DIR FOUND_VERSION)
 endfunction(check_hint)
 
 if(ALLOW_STORM_SYSTEM)
-    set(STORM_MIN_VERSION "1.11.0")
+    set(STORM_MIN_VERSION "1.11.1")
     if (ALLOW_STORM_FETCH)
         find_package(storm HINTS ${STORM_DIR_HINT}) # NOT REQUIRED, can be fetched.
     else()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ CARLPARSER_DIR_HINT=""
 COMPILE_WITH_CCACHE="ON"
 STORMPY_DISABLE_SIGNATURE_DOC="OFF"
 STORM_GIT_REPO="https://github.com/moves-rwth/storm.git"
-STORM_GIT_TAG="1.11.0"
+STORM_GIT_TAG="1.11.1"
 
 
 [tool.scikit-build.metadata.version]


### PR DESCRIPTION
Auto-generated pull request triggered by a new Storm version.
- Manually close and reopen this PR to trigger the CI.