### PR TITLE
Fix for Intel wheels

### DIFF
--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -40,7 +40,7 @@ jobs:
           - os: macos-intel
             runs-on: macos-15-intel # x86_64 runner
             xcode: latest-stable
-            deploy_target: 14.0
+            deploy_target: 15.0
           - os: macos-arm
             runs-on: macos-14 # macos-14+ (including latest) are ARM64 runners
             xcode: latest-stable

--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -163,20 +163,20 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - {name: "XCode 14.3, Intel",
-             os: macos-intel,
-             distro: "macos-13",
-             xcode: "14.3"
-          }
           - {name: "XCode 15.4, ARM",
              os: macos-arm,
              distro: "macos-14",
              xcode: "15.4"
           }
-          - {name: "XCode 16.3, ARM",
+          - {name: "XCode Latest, ARM",
              os: macos-arm,
              distro: "macos-15",
-             xcode: "16.3"
+             xcode: "latest-stable"
+          }
+          - {name: "XCode Latest, Intel",
+             os: macos-intel,
+             distro: "macos-15-intel",
+             xcode: "latest-stable"
           }
     steps:
       - uses: maxim-lobanov/setup-xcode@v1

--- a/doc/checklist_new_release.md
+++ b/doc/checklist_new_release.md
@@ -5,6 +5,8 @@ The following steps should be performed when releasing a new stormpy version.
    To manually update the Storm version:
    * change `STORM_MIN_VERSION` in `CMakeLists.txt`
    * change `STORM_GIT_TAG` in `pyproject.toml`
+   Note that the CI test use the Docker `storm:ci` images which are only updated once per day.
+   The CI fails if the new Storm version is not yet present in these CI Docker images.
 
 2. Check that the stormpy [CI](https://github.com/moves-rwth/stormpy/actions/) builds without errors and all tests are successful.
 


### PR DESCRIPTION
Needed to bump deploy target for MacOS Intel, see [CI test error](https://github.com/moves-rwth/stormpy/actions/runs/18218167619/job/51871981700).