### PR TITLE
CI for weekly wheels

### DIFF
--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -64,7 +64,7 @@ jobs:
           xcode-version: ${{ matrix.xcode }}
       - name: Prepare version
         if: ${{ inputs.dev_version }}
-        run: sed -i -E 's/__version__ = "(.+)"/__version__ = "\1.dev1"/' lib/stormpy/_version.py
+        run: perl -i -pe 's/__version__ = "(.+)"/__version__ = "\1.dev1"/' lib/stormpy/_version.py
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.0
         env:
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare version
         if: ${{ inputs.dev_version }}
-        run: sed -i -E 's/__version__ = "(.+)"/__version__ = "\1.dev1"/' lib/stormpy/_version.py
+        run: perl -i -pe 's/__version__ = "(.+)"/__version__ = "\1.dev1"/' lib/stormpy/_version.py
       - name: Build sdist
         run: pipx run build --sdist
       - uses: actions/upload-artifact@v6

--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -9,6 +9,11 @@ on:
         required: true
         type: string
         default: 'x.y.z'
+      dev_version:
+        description: 'Whether to build a dev version i.e. stormpy version 1.1.0.dev1'
+        required: true
+        type: boolean
+        default: false
   # needed to trigger the workflow manually
   workflow_dispatch:
     inputs:
@@ -17,6 +22,11 @@ on:
         required: true
         type: string
         default: 'x.y.z'
+      dev_version:
+        description: 'Whether to build a dev version i.e. stormpy version 1.1.0.dev1'
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   build_wheels:
@@ -52,6 +62,9 @@ jobs:
         if: ${{ matrix.xcode != '' }}
         with:
           xcode-version: ${{ matrix.xcode }}
+      - name: Prepare version
+        if: ${{ inputs.dev_version }}
+        run: sed -i -E 's/__version__ = "(.+)"/__version__ = "\1.dev1"/' lib/stormpy/_version.py
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.0
         env:
@@ -70,6 +83,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Prepare version
+        if: ${{ inputs.dev_version }}
+        run: sed -i -E 's/__version__ = "(.+)"/__version__ = "\1.dev1"/' lib/stormpy/_version.py
       - name: Build sdist
         run: pipx run build --sdist
       - uses: actions/upload-artifact@v6

--- a/.github/workflows/create_wheel_scheduled.yml
+++ b/.github/workflows/create_wheel_scheduled.yml
@@ -1,0 +1,20 @@
+name: Scheduled build and test wheels
+# Scheduled build and test of wheels for stormpy
+# Calls the general workflow create_wheel.yml with the right arguments
+
+on:
+  schedule:
+    # run weekly
+    - cron: '0 18 * * 7'
+  # needed to trigger the workflow manually
+  workflow_dispatch:
+
+
+jobs:
+  create_wheels:
+    # Create wheels for stormpy
+    uses: ./.github/workflows/create_wheel.yml
+    with:
+      storm_version: "master"
+    secrets: inherit
+

--- a/.github/workflows/create_wheel_scheduled.yml
+++ b/.github/workflows/create_wheel_scheduled.yml
@@ -16,5 +16,6 @@ jobs:
     uses: ./.github/workflows/create_wheel.yml
     with:
       storm_version: "master"
+      dev_version: true
     secrets: inherit
 

--- a/.github/workflows/create_wheel_scheduled.yml
+++ b/.github/workflows/create_wheel_scheduled.yml
@@ -5,7 +5,7 @@ name: Scheduled build and test wheels
 on:
   schedule:
     # run weekly
-    - cron: '0 18 * * 7'
+    - cron: '0 18 * * SUN'
   # needed to trigger the workflow manually
   workflow_dispatch:
 


### PR DESCRIPTION
The original workflow `create_wheel.yml` needs the Storm version as input argument. This wrapper workflow is scheduled each week to build the wheels for the current master of Storm.