### PR TITLE
Require Python >= 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     { name = "S. Junges", email = "sebastian.junges@ru.nl" },
     { name = "M. Volk", email = "m.volk@tue.nl" }
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "Deprecated",
 ]


### PR DESCRIPTION
Python 3.9 reached its [end of life](https://devguide.python.org/versions/).