### PR TITLE
Extended support for collecting parameters

### DIFF
--- a/doc/source/doc/parametric_models.ipynb
+++ b/doc/source/doc/parametric_models.ipynb
@@ -36,7 +36,7 @@
     "formula_str = \"P=? [F s=7 & d=2]\"\n",
     "properties = stormpy.parse_properties(formula_str, prism_program)\n",
     "model = stormpy.build_parametric_model(prism_program, properties)\n",
-    "parameters = model.collect_probability_parameters()\n",
+    "parameters = model.collect_all_parameters()\n",
     "for x in parameters:\n",
     "    print(x)"
    ]

--- a/examples/building_models/02-building-models.py
+++ b/examples/building_models/02-building-models.py
@@ -24,7 +24,7 @@ def example_building_models_02():
     path = stormpy.examples.files.drn_pdtmc_die
     model = stormpy.build_parametric_model_from_drn(path)
 
-    parameters = model.collect_probability_parameters()
+    parameters = model.collect_all_parameters()
     bar_parameters = dict()
     for p in parameters:
         # Ensure that variables with that name are not recognized by pycarl.

--- a/examples/parametric_models/01-parametric-models.py
+++ b/examples/parametric_models/01-parametric-models.py
@@ -13,7 +13,7 @@ def example_parametric_models_01():
     properties = stormpy.parse_properties_for_prism_program(formula_str, prism_program)
     model = stormpy.build_parametric_model(prism_program, properties)
     print("Model supports parameters: {}".format(model.supports_parameters))
-    parameters = model.collect_probability_parameters()
+    parameters = model.collect_all_parameters()
     assert len(parameters) == 2
 
     instantiator = stormpy.pars.PDtmcInstantiator(model)

--- a/lib/stormpy/examples/files.py
+++ b/lib/stormpy/examples/files.py
@@ -13,45 +13,59 @@ def _path(folder, file):
     return os.path.join(testfile_dir, folder, file)
 
 
+# DTMC
 prism_dtmc_die = _path("dtmc", "die.pm")
-"""Knuth Yao Die Example"""
-prism_pdtmc_die = _path("pdtmc", "parametric_die.pm")
-"""Knuth Yao Die -- 2 unfair coins Example"""
-prism_dtmc_brp = _path("dtmc", "brp-16-2.pm")
-"""Bounded Retransmission Protocol"""
-prism_ma_simple = _path("ma", "simple.ma")
-"""Prism file for a simple Markov automaton"""
-drn_ctmc_dft = _path("ctmc", "dft.drn")
-"""DRN format for a CTMC from a DFT"""
-drn_pdtmc_die = _path("pdtmc", "die.drn")
-"""DRN format for a pDTMC for the KY-Die"""
+"""Prism version of Knuth Yao Die example"""
 jani_dtmc_die = _path("dtmc", "die.jani")
-"""Jani Version of Knuth Yao Die Example"""
+"""Jani version of Knuth Yao Die example"""
+prism_dtmc_brp = _path("dtmc", "brp-16-2.pm")
+"""Prism version of Bounded Retransmission Protocol"""
+
+prism_pdtmc_die = _path("pdtmc", "parametric_die.pm")
+"""Prism version of Knuth Yao Die with 2 unfair coins"""
+drn_pdtmc_die = _path("pdtmc", "die.drn")
+"""DRN format of a parametric version of the Knuth Yao Die"""
 prism_pdtmc_brp = _path("pdtmc", "brp16_2.pm")
-"""Bounded retransmission protocol with parameters"""
+"""Prism version of Bounded Retransmission Protocol with parameters"""
+
+# MDP
 prism_mdp_coin_2_2 = _path("mdp", "coin2-2.nm")
-""""""
+"""Prism version of 2-coin Knuth-Yao Die"""
 prism_mdp_firewire = _path("mdp", "firewire.nm")
-"""Prism example for coin MDP"""
-prism_pmdp_coin_two_dice = _path("pmdp", "two_dice.nm")
-"""Prism example for parametric two dice"""
+"""Prism version for Firewire protocol"""
 prism_mdp_maze = _path("mdp", "maze_2.nm")
-"""Prism example for the maze MDP"""
+"""Prism version of maze MDP"""
 prism_mdp_slipgrid = _path("mdp", "slipgrid.nm")
-"""Prism example for the maze MDP towards sketching"""
+"""Prism version of maze MDP towards sketching"""
 prism_mdp_slipgrid_sketch = _path("mdp", "slipgrid_sketch.nm")
-"""Prism example for a slippery grid with fixed dimensions"""
-drn_pomdp_maze = _path("pomdp", "maze.drn")
-"""DRN example for the maze POMDP"""
+"""Prism version of a slippery grid with fixed dimensions"""
+prism_pmdp_coin_two_dice = _path("pmdp", "two_dice.nm")
+"""Prism version of parametric two dice"""
+
+# CTMC
+drn_ctmc_dft = _path("ctmc", "dft.drn")
+"""DRN format of a CTMC from a DFT"""
+
+# MA
+prism_ma_simple = _path("ma", "simple.ma")
+"""Prism version of a simple Markov automaton"""
+
+# POMDP
 prism_pomdp_maze = _path("pomdp", "maze_2.prism")
-"""Prism example for the maze POMDP"""
+"""Prism version of the maze POMDP"""
+drn_pomdp_maze = _path("pomdp", "maze.drn")
+"""DRN format of the maze POMDP"""
 prism_par_pomdp_maze = _path("pomdp", "maze_2_par.prism")
-"""Prism example for the parametric POMDP"""
+"""Prism version of the parametric maze POMDP"""
+
+# DFT
 dft_galileo_hecs = _path("dft", "hecs.dft")
-"""DFT example for HECS (Galileo format)"""
+"""DFT in Galileo format for HECS"""
 dft_json_and = _path("dft", "and.json")
-"""DFT example for AND gate (JSON format)"""
+"""DFT in JSON format for simple AND gate"""
+
+# GSPN
 gspn_pnpro_simple = _path("gspn", "gspn_simple.pnpro")
-"""GSPN example (PNPRO format)"""
+"""GSPN example in PNPRO format"""
 gspn_pnml_simple = _path("gspn", "gspn_simple.pnml")
-"""GSPN example (PNML format)"""
+"""GSPN example in PNML format"""

--- a/lib/stormpy/examples/files/pctmc/polling3.sm
+++ b/lib/stormpy/examples/files/pctmc/polling3.sm
@@ -1,0 +1,56 @@
+// polling example [IT90]
+// gxn/dxp 26/01/00
+
+ctmc
+
+const int N = 3;
+
+const double mu; // default 1
+const double gamma; // default 200
+const double lambda	= mu/N;
+
+module server
+	
+	s : [1..N]; // station
+	a : [0..1]; // action: 0=polling, 1=serving
+	
+	[loop1a] (s=1)&(a=0) -> gamma	: (s'=s+1);
+	[loop1b] (s=1)&(a=0) -> gamma	: (a'=1);
+	[serve1] (s=1)&(a=1) -> mu		: (s'=s+1)&(a'=0);
+	
+	[loop2a] (s=2)&(a=0) -> gamma	: (s'=s+1);
+	[loop2b] (s=2)&(a=0) -> gamma	: (a'=1);
+	[serve2] (s=2)&(a=1) -> mu		: (s'=s+1)&(a'=0);
+	
+	[loop3a] (s=3)&(a=0) -> gamma	: (s'=1);
+	[loop3b] (s=3)&(a=0) -> gamma	: (a'=1);
+	[serve3] (s=3)&(a=1) -> mu		: (s'=1)&(a'=0);
+	
+endmodule
+
+module station1
+	
+	s1 : [0..1]; // state of station: 0=empty, 1=full
+	
+	[loop1a] (s1=0) -> 1 : (s1'=0);
+	[]       (s1=0) -> lambda : (s1'=1);
+	[loop1b] (s1=1) -> 1 : (s1'=1);
+	[serve1] (s1=1) -> 1 : (s1'=0);
+	
+endmodule
+
+// construct further stations through renaming
+
+module station2 = station1 [ s1=s2, loop1a=loop2a, loop1b=loop2b, serve1=serve2 ] endmodule
+module station3 = station1 [ s1=s3, loop1a=loop3a, loop1b=loop3b, serve1=serve3 ] endmodule
+// (cumulative) rewards
+
+// expected time station 1 is waiting to be served
+rewards "waiting"
+	s1=1 & !(s=1 & a=1) : 1;
+endrewards
+
+// expected number of times station 1 is served
+rewards "served"
+	[serve1] true : 1;
+endrewards

--- a/src/storage/model.cpp
+++ b/src/storage/model.cpp
@@ -255,6 +255,9 @@ void define_sparse_model(py::module& m, std::string const& vtSuffix) {
             .def("collect_reward_parameters", [](SparseModel<ValueType> const& model) -> std::set<storm::RationalFunctionVariable> {
                 return storm::models::sparse::getRewardParameters(model);
 	     }, "Collect reward parameters")
+            .def("collect_rate_parameters", [](SparseModel<ValueType> const& model) -> std::set<storm::RationalFunctionVariable> {
+                return storm::models::sparse::getRateParameters(model);
+	     }, "Collect rate parameters")
             .def("collect_all_parameters", [](SparseModel<ValueType> const& model) -> std::set<storm::RationalFunctionVariable> {
                 return storm::models::sparse::getAllParameters(model);
 	     }, "Collect all parameters")

--- a/tests/pars/test_model_instantiator.py
+++ b/tests/pars/test_model_instantiator.py
@@ -11,7 +11,7 @@ class TestModelInstantiator:
         program = stormpy.parse_prism_program(get_example_path("pdtmc", "brp16_2.pm"))
         formulas = stormpy.parse_properties_for_prism_program("P=? [ F s=5 ]", program)
         model = stormpy.build_parametric_model(program, formulas)
-        parameters = model.collect_probability_parameters()
+        parameters = model.collect_all_parameters()
         assert len(parameters) == 2
         instantiator = stormpy.pars.ModelInstantiator(model)
 
@@ -30,7 +30,7 @@ class TestModelInstantiator:
         formulas = stormpy.parse_properties_for_prism_program('P=? [F "error"]', program)
         model = stormpy.build_parametric_model(program, formulas)
 
-        parameters = model.collect_probability_parameters()
+        parameters = model.collect_all_parameters()
         instantiator = stormpy.pars.PDtmcInstantiator(model)
 
         point = {p: stormpy.RationalRF("0.4") for p in parameters}
@@ -48,7 +48,7 @@ class TestModelInstantiator:
         formulas = stormpy.parse_properties_for_prism_program('R=? [F "stable"]', program)
         model = stormpy.build_parametric_model(program, formulas)
 
-        parameters = model.collect_probability_parameters()
+        parameters = model.collect_all_parameters()
         inst_checker = stormpy.pars.PDtmcInstantiationChecker(model)
         inst_checker.specify_formula(stormpy.ParametricCheckTask(formulas[0].raw_formula, True))
         inst_checker.set_graph_preserving(True)
@@ -66,7 +66,7 @@ class TestModelInstantiator:
         formulas = stormpy.parse_properties_for_prism_program('R=? [F "stable"]', program)
         model = stormpy.build_parametric_model(program, formulas)
 
-        parameters = model.collect_probability_parameters()
+        parameters = model.collect_all_parameters()
         inst_checker = stormpy.pars.PDtmcExactInstantiationChecker(model)
         inst_checker.specify_formula(stormpy.ParametricCheckTask(formulas[0].raw_formula, True))
         inst_checker.set_graph_preserving(True)

--- a/tests/pars/test_parametric.py
+++ b/tests/pars/test_parametric.py
@@ -127,7 +127,7 @@ class TestParametric:
         assert model.nr_transitions == 803
         assert model.model_type == stormpy.ModelType.DTMC
         assert model.has_parameters
-        parameters = model.collect_probability_parameters()
+        parameters = model.collect_all_parameters()
         assert len(parameters) == 2
         derivatives = stormpy.pars.gather_derivatives(model, list(parameters)[0])
         assert len(derivatives) == 0
@@ -160,7 +160,7 @@ class TestParametric:
         prop = "P<=0.84 [F s=5 ]"
         formulas = stormpy.parse_properties_for_prism_program(prop, program)
         model = stormpy.build_parametric_model(program, formulas)
-        parameters = model.collect_probability_parameters()
+        parameters = model.collect_all_parameters()
         assert len(parameters) == 2
         region = stormpy.pars.ParameterRegion.create_from_string("0.7<=pL<=0.9,0.75<=pK<=0.95", parameters)
         assert region.area == stormpy.RationalRF(1) / stormpy.RationalRF(25)

--- a/tests/pars/test_parametric.py
+++ b/tests/pars/test_parametric.py
@@ -49,32 +49,51 @@ class TestParametric:
         values = result.get_values()
         assert len(values) == 3
 
-    def test_parameters(self):
+    def test_parameters_dtmc(self):
         program = stormpy.parse_prism_program(get_example_path("pdtmc", "brp16_2.pm"))
         formulas = stormpy.parse_properties_for_prism_program("P=? [F s=5]", program)
         model = stormpy.build_parametric_model(program, formulas)
         model_parameters = model.collect_probability_parameters()
         reward_parameters = model.collect_reward_parameters()
+        rate_parameters = model.collect_rate_parameters()
         all_parameters = model.collect_all_parameters()
         assert len(model_parameters) == 2
         assert len(reward_parameters) == 0
+        assert len(rate_parameters) == 0
         assert len(all_parameters) == 2
+
+        model = stormpy.build_symbolic_parametric_model(program, formulas)
+        assert len(model.get_parameters()) == 4
 
         program_reward = stormpy.parse_prism_program(get_example_path("pdtmc", "brp_rewards16_2.pm"))
         formulas_reward = stormpy.parse_properties_for_prism_program('Rmin=? [ F "target" ]', program_reward)
         model = stormpy.build_parametric_model(program_reward, formulas_reward)
         model_parameters = model.collect_probability_parameters()
         reward_parameters = model.collect_reward_parameters()
+        rate_parameters = model.collect_rate_parameters()
         all_parameters = model.collect_all_parameters()
         assert len(model_parameters) == 2
         assert len(reward_parameters) == 2
+        assert len(rate_parameters) == 0
         assert len(all_parameters) == 4
-
-        model = stormpy.build_symbolic_parametric_model(program, formulas)
-        assert len(model.get_parameters()) == 4
 
         model = stormpy.build_symbolic_parametric_model(program_reward, formulas_reward)
         assert len(model.get_parameters()) == 4
+
+    def test_parameters_ctmc(self):
+        program = stormpy.parse_prism_program(get_example_path("pctmc", "polling3.sm"), True)
+        model = stormpy.build_parametric_model(program)
+        model_parameters = model.collect_probability_parameters()
+        reward_parameters = model.collect_reward_parameters()
+        rate_parameters = model.collect_rate_parameters()
+        all_parameters = model.collect_all_parameters()
+        assert len(model_parameters) == 2
+        assert len(reward_parameters) == 0
+        assert len(rate_parameters) == 2
+        assert len(all_parameters) == 2
+
+        model = stormpy.build_symbolic_parametric_model(program)
+        assert len(model.get_parameters()) == 2
 
     def test_constraints_collector(self):
         from stormpy.pycarl.formula import FormulaType, Relation

--- a/tests/pars/test_pla.py
+++ b/tests/pars/test_pla.py
@@ -24,7 +24,7 @@ class TestPLA:
         assert model.has_parameters
         env = stormpy.Environment()
         checker = stormpy.pars.create_region_checker(env, model, formulas[0].raw_formula)
-        parameters = model.collect_probability_parameters()
+        parameters = model.collect_all_parameters()
         assert len(parameters) == 2
         region = stormpy.pars.ParameterRegion.create_from_string("0.7<=pL<=0.9,0.75<=pK<=0.95", parameters)
         result = checker.check_region(env, region)
@@ -47,7 +47,7 @@ class TestPLA:
         assert model.has_parameters
         env = stormpy.Environment()
         checker = stormpy.pars.create_region_checker(env, model, formulas[0].raw_formula)
-        parameters = model.collect_probability_parameters()
+        parameters = model.collect_all_parameters()
         assert len(parameters) == 2
         for par in parameters:
             if par.name == "pL":
@@ -80,7 +80,7 @@ class TestPLA:
         assert model.has_parameters
         env = stormpy.Environment()
         checker = stormpy.pars.create_region_checker(env, model, formulas[0].raw_formula)
-        parameters = model.collect_probability_parameters()
+        parameters = model.collect_all_parameters()
         assert len(parameters) == 2
         region = stormpy.pars.ParameterRegion.create_from_string("0.7<=pL<=0.9,0.75<=pK<=0.95", parameters)
         result = checker.get_bound(env, region, True)
@@ -98,7 +98,7 @@ class TestPLA:
         env = stormpy.Environment()
         checker = stormpy.pars.DtmcParameterLiftingModelChecker()
         checker.specify(env, model, formulas[0].raw_formula)
-        parameters = model.collect_probability_parameters()
+        parameters = model.collect_all_parameters()
         assert len(parameters) == 2
         region = stormpy.pars.ParameterRegion.create_from_string("0.7<=pL<=0.9,0.75<=pK<=0.95", parameters)
         result = checker.get_bound(env, region, True)
@@ -113,7 +113,7 @@ class TestPLA:
         env = stormpy.Environment()
         checker = stormpy.pars.DtmcParameterLiftingModelChecker()
         checker.specify(env, model, formulas[0].raw_formula, allow_model_simplification=False)
-        parameters = model.collect_probability_parameters()
+        parameters = model.collect_all_parameters()
         assert len(parameters) == 2
         region = stormpy.pars.ParameterRegion.create_from_string("0.7<=pL<=0.9,0.75<=pK<=0.95", parameters)
         result = checker.get_bound(env, region, True)
@@ -128,7 +128,7 @@ class TestPLA:
         env = stormpy.Environment()
         checker = stormpy.pars.DtmcParameterLiftingModelChecker()
         checker.specify(env, model, formulas[0].raw_formula, allow_model_simplification=False)
-        parameters = model.collect_probability_parameters()
+        parameters = model.collect_all_parameters()
         assert len(parameters) == 2
         region = stormpy.pars.ParameterRegion.create_from_string("0.7<=pL<=0.9,0.75<=pK<=0.95", parameters)
         result_vec = checker.get_bound_all_states(env, region, True)
@@ -142,7 +142,7 @@ class TestPLA:
         model = stormpy.build_parametric_model(program, formulas)
         assert model.has_parameters
         env = stormpy.Environment()
-        parameters = model.collect_probability_parameters()
+        parameters = model.collect_all_parameters()
         assert len(parameters) == 2
         region = stormpy.pars.ParameterRegion.create_from_string("0.7<=pL<=0.9,0.75<=pK<=0.95", parameters)
 


### PR DESCRIPTION
- Replaced `collect_probability_parameters` by more general `collect_all_parameters`. I think this should be the method to use by default.
- Added binding `collect_rate_parameters`
- Added test for pCTMC

Depends on https://github.com/moves-rwth/storm/pull/858