### PR TITLE
Update to use UncertaintyResolutionMode instead of robustUncertainty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =============
 
+### Version dev
+
+- Improved support for model checking of interval DTMC/MDP
+  - Set uncertainty resolution via `CheckTask.set_uncertainty_resolution_mode` which replaces `set_robust_uncertainty`
+
 Version 1.11.x
 --------------
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -10,6 +10,7 @@
 #include "storm/storage/dd/DdType.h"
 #include "storm/storage/jani/Property.h"
 #include "storm/solver/OptimizationDirection.h"
+#include "storm/solver/UncertaintyResolutionMode.h"
 #include "storm/models/symbolic/StandardRewardModel.h"
 #include "storm/generator/NextStateGenerator.h"
 #include "storm-parsers/api/storm-parsers.h"
@@ -176,6 +177,14 @@ void define_optimality_type(py::module& m) {
     py::enum_<storm::solver::OptimizationDirection>(m, "OptimizationDirection")
         .value("Minimize", storm::solver::OptimizationDirection::Minimize)
         .value("Maximize", storm::solver::OptimizationDirection::Maximize)
+    ;
+
+    py::enum_<storm::solver::UncertaintyResolutionMode>(m, "UncertaintyResolutionMode")
+        .value("MINIMIZE", storm::solver::UncertaintyResolutionMode::Minimize)
+        .value("MAXIMIZE", storm::solver::UncertaintyResolutionMode::Maximize)
+        .value("ROBUST", storm::solver::UncertaintyResolutionMode::Robust)
+        .value("COOPERATIVE", storm::solver::UncertaintyResolutionMode::Cooperative)
+        .value("UNSET", storm::solver::UncertaintyResolutionMode::Unset)
     ;
 }
 

--- a/src/core/modelchecking.cpp
+++ b/src/core/modelchecking.cpp
@@ -9,7 +9,6 @@
 #include "storm/modelchecker/hints/ExplicitModelCheckerHint.h"
 #include "storm/modelchecker/csl/helper/SparseCtmcCslHelper.h"
 #include "storm/modelchecker/multiobjective/MultiObjectiveModelChecking.h"
-#include "storm/environment/Environment.h"
 #include "storm/utility/graph.h"
 
 template<typename ValueType>
@@ -99,28 +98,19 @@ storm::storage::BitVector getReachableStates(storm::models::sparse::Model<ValueT
 
 }
 
-// Define python bindings
-void define_modelchecking(py::module& m) {
+// TODO: use consistent suffix instead of name
+template<typename ValueType>
+void define_check_task(py::module& m, std::string const& name) {
+    // CheckTask
+    py::class_<CheckTask<ValueType>, std::shared_ptr<CheckTask<ValueType>>>(m, name.c_str(), "Task for model checking")
+        .def(py::init<storm::logic::Formula const&, bool>(), py::arg("formula"), py::arg("only_initial_states") = false)
+        .def("set_produce_schedulers", &CheckTask<ValueType>::setProduceSchedulers, "Set whether schedulers should be produced (if possible)", py::arg("produce_schedulers") = true)
+        .def("set_hint", &CheckTask<ValueType>::setHint, "Sets a hint that may speed up the solver")
+        .def("set_uncertainty_resolution_mode", &CheckTask<ValueType>::setUncertaintyResolutionMode, "Sets the mode which decides how the uncertainty will be resolved.")
+    ;
+}
 
-    // CheckTask
-    py::class_<CheckTask<double>, std::shared_ptr<CheckTask<double>>>(m, "CheckTask", "Task for model checking")
-    //m.def("create_check_task", &storm::api::createTask, "Create task for verification", py::arg("formula"), py::arg("only_initial_states") = false);
-        .def(py::init<storm::logic::Formula const&, bool>(), py::arg("formula"), py::arg("only_initial_states") = false)
-        .def("set_produce_schedulers", &CheckTask<double>::setProduceSchedulers, "Set whether schedulers should be produced (if possible)", py::arg("produce_schedulers") = true)
-        .def("set_hint", &CheckTask<double>::setHint, "Sets a hint that may speed up the solver")
-        .def("set_robust_uncertainty", &CheckTask<double>::setRobustUncertainty, "Sets whether robust uncertainty should be considered")
-    ;
-    // CheckTask
-    py::class_<CheckTask<storm::RationalNumber>, std::shared_ptr<CheckTask<storm::RationalNumber>>>(m, "ExactCheckTask", "Task for model checking with exact numbers")
-            //m.def("create_check_task", &storm::api::createTask, "Create task for verification", py::arg("formula"), py::arg("only_initial_states") = false);
-            .def(py::init<storm::logic::Formula const&, bool>(), py::arg("formula"), py::arg("only_initial_states") = false)
-            .def("set_produce_schedulers", &CheckTask<storm::RationalNumber>::setProduceSchedulers, "Set whether schedulers should be produced (if possible)", py::arg("produce_schedulers") = true)
-            ;
-    py::class_<CheckTask<storm::RationalFunction>, std::shared_ptr<CheckTask<storm::RationalFunction>>>(m, "ParametricCheckTask", "Task for parametric model checking")
-    //m.def("create_check_task", &storm::api::createTask, "Create task for verification", py::arg("formula"), py::arg("only_initial_states") = false);
-        .def(py::init<storm::logic::Formula const&, bool>(), py::arg("formula"), py::arg("only_initial_states") = false)
-        .def("set_produce_schedulers", &CheckTask<storm::RationalFunction>::setProduceSchedulers, "Set whether schedulers should be produced (if possible)", py::arg("produce_schedulers") = true)
-    ;
+void define_modelchecking(py::module& m) {
 
     py::class_<storm::modelchecker::ModelCheckerHint, std::shared_ptr<storm::modelchecker::ModelCheckerHint>> mchint(m, "ModelCheckerHint", "Information that may accelerate the model checking process");
     py::class_<storm::modelchecker::ExplicitModelCheckerHint<double>>(m, "ExplicitModelCheckerHintDouble", "Information that may accelerate an explicit state model checker", mchint)
@@ -162,3 +152,7 @@ void define_modelchecking(py::module& m) {
     m.def("_multi_objective_model_checking_double", &multiObjectiveModelChecking<double>, "Run multi-objective model checking",  py::arg("model"), py::arg("formula"), py::arg("environment") = storm::Environment());
     m.def("_multi_objective_model_checking_exact", &multiObjectiveModelChecking<storm::RationalNumber>, "Run multi-objective model checking", py::arg("model"), py::arg("formula"), py::arg("environment") = storm::Environment());
 }
+
+template void define_check_task<double>(py::module&, std::string const&);
+template void define_check_task<storm::RationalNumber>(py::module&, std::string const&);
+template void define_check_task<storm::RationalFunction>(py::module&, std::string const&);

--- a/src/core/modelchecking.h
+++ b/src/core/modelchecking.h
@@ -1,8 +1,9 @@
-#ifndef PYTHON_CORE_MODELCHECKING_H_
-#define PYTHON_CORE_MODELCHECKING_H_
+#pragma once
 
 #include "common.h"
 
+template<typename ValueType>
+void define_check_task(py::module& m, std::string const& name);
+
 void define_modelchecking(py::module& m);
 
-#endif /* PYTHON_CORE_MODELCHECKING_H_ */

--- a/src/mod_core.cpp
+++ b/src/mod_core.cpp
@@ -28,6 +28,9 @@ PYBIND11_MODULE(_core, m) {
     define_optimality_type(m);
     define_export(m);
     define_result(m);
+    define_check_task<double>(m, "CheckTask");
+    define_check_task<storm::RationalNumber>(m, "ExactCheckTask");
+    define_check_task<storm::RationalFunction>(m, "ParametricCheckTask");
     define_modelchecking(m);
     define_counterexamples(m);
     define_bisimulation(m);

--- a/tests/core/test_modelchecking.py
+++ b/tests/core/test_modelchecking.py
@@ -56,22 +56,22 @@ class TestModelChecking:
         task = stormpy.CheckTask(formulas[0].raw_formula, only_initial_states=True)
         task.set_produce_schedulers()
         # Compute maximal robust
-        task.set_robust_uncertainty(True)
+        task.set_uncertainty_resolution_mode(stormpy.UncertaintyResolutionMode.ROBUST)
         result = stormpy.check_interval_mdp(model, task, env)
         assert math.isclose(result.at(initial_state), 0.4, rel_tol=1e-4)
-        # Compute maximal non-robust
-        task.set_robust_uncertainty(False)
+        # Compute maximal cooperative
+        task.set_uncertainty_resolution_mode(stormpy.UncertaintyResolutionMode.COOPERATIVE)
         result = stormpy.check_interval_mdp(model, task, env)
         assert math.isclose(result.at(initial_state), 0.5, rel_tol=1e-4)
 
         task = stormpy.CheckTask(formulas[1].raw_formula, only_initial_states=True)
         task.set_produce_schedulers()
         # Compute minimal robust
-        task.set_robust_uncertainty(True)
+        task.set_uncertainty_resolution_mode(stormpy.UncertaintyResolutionMode.ROBUST)
         result = stormpy.check_interval_mdp(model, task, env)
         assert math.isclose(result.at(initial_state), 0.5, rel_tol=1e-4)
-        # Compute minimal non-robust
-        task.set_robust_uncertainty(False)
+        # Compute minimal cooperative
+        task.set_uncertainty_resolution_mode(stormpy.UncertaintyResolutionMode.COOPERATIVE)
         result = stormpy.check_interval_mdp(model, task, env)
         assert math.isclose(result.at(initial_state), 0.4, rel_tol=1e-4)
 


### PR DESCRIPTION
Adaption to changes in moves-rwth/storm#808

 Uncertainty resolution can be set via `CheckTask.set_uncertainty_resolution_mode` which replaces the previously used `set_robust_uncertainty`.

Moved to templated instantiations for `CheckTask`. The naming is not yet consistent though, see #326.