### PR TITLE
Support for formatting C++ code via clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,155 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     160
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<storm/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        c++20
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+...
+

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,2 @@
+# Contains file path patterns that clang-format should ignore.
+# Currently intentionally left empty.

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,6 @@
+# Lists commit hashs that can safely be ignored when checking the git history with git blame.
+# Use 'git blame --ignore-revs-file .git-blame-ignore-revs'.
+# The apply-code-format workflow automatically appends relevant hashs to this file.
+
 534f29c9e329007d67428da3ef7be84141140fe2
 111723001581254265076802b8b50f581fae43fd

--- a/.github/workflows/formatapply.yml
+++ b/.github/workflows/formatapply.yml
@@ -4,17 +4,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  format:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
+      # First format Python
       - uses: psf/black@stable
         with:
           options: ""
           src: "."
           jupyter: true
-      - name: Commit Formatting
+      - name: Commit Formatting for Python
         run: |
           git config user.name 'Auto Format'
           git config user.email 'dev@stormchecker.org'
@@ -22,7 +23,33 @@ jobs:
           then
           echo "Code did not change"
           else
-          git commit -am "Applied code formatting"
+          git commit -am "Applied code formatting for Python"
+          git rev-parse HEAD >> .git-blame-ignore-revs
+          git commit -am "Add code formatting commit to .git-blame-ignore-revs"
+          fi
+      # Second format C++
+      # apply the formatting twice as a workaround for a clang-format bug
+      - uses: DoozyX/clang-format-lint-action@v0.20
+        with:
+          source: './src'
+          clangFormatVersion: 20
+          style: file
+          inplace: True
+      - uses: DoozyX/clang-format-lint-action@v0.20
+        with:
+          source: './src'
+          clangFormatVersion: 20
+          style: file
+          inplace: True
+      - name: Commit Formatting for C++
+        run: |
+          git config user.name 'Auto Format'
+          git config user.email 'dev@stormchecker.org'
+          if [ -z "$(git status --porcelain)" ]
+          then
+          echo "Code did not change"
+          else
+          git commit -am "Applied code formatting for C++"
           git rev-parse HEAD >> .git-blame-ignore-revs
           git commit -am "Add code formatting commit to .git-blame-ignore-revs"
           fi
@@ -37,3 +64,4 @@ jobs:
             Auto-generated pull request triggered by the `apply-code-format` workflow.
             - Manually close and reopen this PR to trigger the CI.
             - Make sure to **merge** (and not rebase) this PR so that the added commit hash in `.git-blame-ignore-revs` remains valid.
+

--- a/.github/workflows/formatcheck.yml
+++ b/.github/workflows/formatcheck.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  check_python:
     runs-on: ubuntu-latest
 
     steps:
@@ -16,3 +16,14 @@ jobs:
         options: "--check --diff --color"
         src: "."
         jupyter: true
+
+  check_cpp:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - uses: DoozyX/clang-format-lint-action@v0.20
+      with:
+        source: './src'
+        clangFormatVersion: 20
+        style: file

--- a/resources/scripts/auto-format.sh
+++ b/resources/scripts/auto-format.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Settings
+auto_format_file_extensions=( .h .cpp )
+auto_format_src_dir=./src
+
+# Set-up directories
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+stormpy_root="$script_dir/../.."
+
+# Sanity checks
+for expected_file in .clang-format .clang-format-ignore
+do
+	if [ ! -f $stormpy_root/$expected_file ]; then
+    	echo "ERROR: There does not seem to be a file '$stormpy_root/$expected_file'. Have you moved this script?"
+		exit 1
+	fi
+done
+if ! command -v clang-format &> /dev/null
+then
+    echo "Unable to find clang-format executable. Is it installed?"
+    exit 1
+fi
+
+# go to correct directory
+cd $stormpy_root
+
+# Build an expression for the find command
+# 1. look in the correct directory
+auto_format_find_expression="$auto_format_src_dir ( ("
+# 2. the file should have one of the specified file extensions
+for extension in "${auto_format_file_extensions[@]}"
+do
+	auto_format_find_expression+=" -name *$extension -or"
+done
+# 3. the file path should not match one of the excluding patterns in .clang-format-ignore
+auto_format_find_expression+=" -false ) -and -not ("
+while read exclude_pattern || [[ -n "$exclude_pattern" ]]
+do
+	if [[ -z "$exclude_pattern" || "$exclude_pattern" == \#* ]]
+	then 
+		continue #ignore white spaces and lines starting with #
+	fi 
+	auto_format_find_expression+=" -path $exclude_pattern -or"
+done < .clang-format-ignore
+auto_format_find_expression+=" -false ) ) -print"
+
+# disable bash expansion of *
+set -f 
+
+# find files and invoke clang-format with in-place option
+find $auto_format_find_expression | xargs clang-format -i -style=file


### PR DESCRIPTION
Added support for clang-format for the C++ bindings in the `src` directory. The formatting can be manually triggered with the script `resources/scripts/auto-format.sh`. The script and `.clang-format` are copied from Storm.

Extended the existing formatting CI (for Python) which now also incorporates the C++ formatting.

After merging this PR, we need to initially run the CI for applying the formatting. A quick local check showed that the formatting will lead to some errors, mainly due to the reordering of includes. These will need to be fixed after applying the formatting.