### PR TITLE
fix warning and fix support for pybind 3.0.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,10 @@ if (NOT USE_PARSER AND CARLPARSER_DIR_HINT)
 	message(WARNING "Stormpy - Carl-parser directory hint was given but USE_PARSER=OFF.")
 endif()
 
+# Find python first, as recommended here:
+# https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode
+# Python version should be synced with pyproject.toml
+find_package(Python 3.10 COMPONENTS Interpreter Development REQUIRED)
 find_package(pybind11 CONFIG REQUIRED)
 message(STATUS "Stormpy - Using pybind11 version ${pybind11_VERSION}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     { name = "S. Junges", email = "sebastian.junges@ru.nl" },
     { name = "M. Volk", email = "m.volk@tue.nl" }
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10" # Also check CMakeLists.txt, in the line with find_package(Python
 dependencies = [
     "Deprecated",
 ]

--- a/src/mod_storage.cpp
+++ b/src/mod_storage.cpp
@@ -22,12 +22,6 @@
 
 PYBIND11_MODULE(_storage, m) {
     m.doc() = "Data structures in Storm";
-
-#ifdef STORMPY_DISABLE_SIGNATURE_DOC
-    py::options options;
-    options.disable_function_signatures();
-#endif
-
     define_bitvector(m);
     define_dd<storm::dd::DdType::Sylvan>(m, "Sylvan");
     define_dd_nt(m);

--- a/src/mod_storage.cpp
+++ b/src/mod_storage.cpp
@@ -22,10 +22,15 @@
 
 PYBIND11_MODULE(_storage, m) {
     m.doc() = "Data structures in Storm";
+
+#ifdef STORMPY_DISABLE_SIGNATURE_DOC
+    py::options options;
+    options.disable_function_signatures();
+#endif
+
     define_bitvector(m);
     define_dd<storm::dd::DdType::Sylvan>(m, "Sylvan");
     define_dd_nt(m);
-
     define_model(m);
     define_sparse_model<double>(m, "");
     define_sparse_model<storm::RationalNumber>(m, "Exact");

--- a/src/storage/model.cpp
+++ b/src/storage/model.cpp
@@ -236,8 +236,8 @@ void define_sparse_model(py::module& m, std::string const& vtSuffix) {
                 return SparseModelStates<ValueType>(model);
             }, "Get states")
         .def_property_readonly("reward_models", [](SparseModel<ValueType>& model) {return model.getRewardModels(); }, "Reward models")
-        .def_property_readonly("transition_matrix", &getTransitionMatrix<ValueType>, py::return_value_policy::reference, py::keep_alive<1, 0>(), "Transition matrix")
-        .def_property_readonly("backward_transition_matrix", &SparseModel<ValueType>::getBackwardTransitions, py::return_value_policy::reference, py::keep_alive<1, 0>(), "Backward transition matrix")
+        .def_property_readonly("transition_matrix", py::cpp_function(&getTransitionMatrix<ValueType>, py::return_value_policy::reference, py::keep_alive<1, 0>()), "Transition matrix")
+        .def_property_readonly("backward_transition_matrix", py::cpp_function(&SparseModel<ValueType>::getBackwardTransitions, py::return_value_policy::reference, py::keep_alive<1, 0>()), "Backward transition matrix")
         .def("get_reward_model", [](SparseModel<ValueType>& model, std::string const& name) -> SparseRewardModel<ValueType>& {return model.getRewardModel(name);}, py::return_value_policy::reference, py::keep_alive<1, 0>(), "Reward model")
         .def("has_reward_model", [](SparseModel<ValueType> const& model, std::string const& name) {return model.hasRewardModel(name);}, py::arg("name"))
         .def("add_reward_model", [](SparseModel<ValueType>& model, std::string const& name, SparseRewardModel<ValueType> const& rewModel) { model.addRewardModel(name, rewModel);})


### PR DESCRIPTION
- Fix broken code that no longer compiles with pybind 3.0.2, using documentation from https://pybind11.readthedocs.io/en/stable/advanced/functions.html.
- Fix warning on new cmake regarding findpython, in accordance also with pybind documentation. 

Fixes #305 