### PR TITLE
Fix Python issue on manylinux

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,7 +14,6 @@ lib/**/_config.py
 **/__pycache__/
 **/_build/
 **/.pytest_cache/
-**/.idea/
 **/cmake-build-debug/
 
 **/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ dist/
 __pycache__/
 _build/
 .pytest_cache/
-.idea/
 cmake-build-debug/
 
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 # Find python first, as recommended here:
 # https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode
 # Python version should be synced with pyproject.toml
-find_package(Python 3.10 COMPONENTS Interpreter Development REQUIRED)
+find_package(Python 3.10 COMPONENTS Interpreter Development.Module REQUIRED)
 find_package(pybind11 CONFIG REQUIRED)
 message(STATUS "Stormpy - Using pybind11 version ${pybind11_VERSION}")
 

--- a/lib/stormpy/info/__init__.py
+++ b/lib/stormpy/info/__init__.py
@@ -49,7 +49,7 @@ def storm_origin_info() -> [str | None, str | None]:
 
     :return: A pair with the repo path and the repo tag.
     """
-    return (_config.STORM_ORIGIN_REPO, _config.STORM_ORIGIN_TAG)
+    return _config.STORM_ORIGIN_REPO, _config.STORM_ORIGIN_TAG
 
 
 def storm_directory() -> str | None:

--- a/tests/storage/test_prism.py
+++ b/tests/storage/test_prism.py
@@ -27,7 +27,7 @@ class TestPrism:
         jani_model, new_properties = program.to_jani(orig_properties, suffix="2")
         assert len(new_properties) == len(orig_properties)
 
-    def test_prism_variables(selfs):
+    def test_prism_variables(self):
         program = stormpy.parse_prism_program(get_example_path("mdp", "leader3.nm"))
         assert program.nr_modules == 3
         assert program.model_type == stormpy.PrismModelType.MDP


### PR DESCRIPTION
Need to use `Development.Module` for `find_package(Python ...)`, see the [second warning in the doc](https://pybind11.readthedocs.io/en/stable/compiling.html#findpython-mode).

Also some tiny cosmetic changes, for example `.idea` occurred twice in the `.gitignore`.