### PR TITLE
Require exact pybind11 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,8 @@ endif()
 # https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode
 # Python version should be synced with pyproject.toml
 find_package(Python 3.10 COMPONENTS Interpreter Development.Module REQUIRED)
-find_package(pybind11 CONFIG REQUIRED)
+# Pybind11 version should be synced with pyproject.toml
+find_package(pybind11 3.0.2 EXACT CONFIG REQUIRED)
 message(STATUS "Stormpy - Using pybind11 version ${pybind11_VERSION}")
 
 # Helper function to print path where library was found and check whether hint was used
@@ -72,6 +73,7 @@ function(check_hint NAME DIR_FOUND HINT_DIR FOUND_VERSION)
 endfunction(check_hint)
 
 if(ALLOW_STORM_SYSTEM)
+    # Version should be synced with STORM_GIT_TAG in pyproject.toml
     set(STORM_MIN_VERSION "1.11.0")
     if (ALLOW_STORM_FETCH)
         find_package(storm HINTS ${STORM_DIR_HINT}) # NOT REQUIRED, can be fetched.

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -1,0 +1,31 @@
+**************
+Developer information
+**************
+
+The following contains some general guidelines for developers.
+
+
+Structure
+=========
+- C++ bindings are defined in ``src``
+- Python methods are defined in ``lib/stormpy``
+- Tests are in ``tests``
+- The Sphinx documentation is in ``doc/source``
+
+
+Coding conventions
+==================
+Formatting
+----------
+- Code should be formatted according to the given rules set by black (for Python).
+  Proper formatting can be ensured by executing ``black .``.
+  The CI checks for proper formatting.
+
+
+Dependencies
+============
+
+- The bindings are created with `pybind11 <https://pybind11.readthedocs.io>`_.
+  The pybind11 version is set in ``pyproject.toml`` through ``requires``, and in ``CMakeLists.txt`` through ``find_package(pybind11 ...)``.
+- The minimal Python version is set in ``pyproject.toml`` through ``requires-python``, and in ``CMakeLists.txt`` through ``find_package(Python ...)``.
+- The `Storm <https://www.stormchecker.org>`_ version is set in ``pyproject.toml`` through ``STORM_GIT_TAG``, and in ``CMakeLists.txt`` through ``STORM_MIN_VERSION``.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -19,6 +19,7 @@ Pycarl is bundled with stormpy. It is a set of python bindings for the computer 
    getting_started
    advanced_topics
    using_pycarl
+   development
    contributors
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["scikit-build-core==0.11.6", "pybind11==3.0.2"]
+requires = [
+    "scikit-build-core==0.11.6",
+    "pybind11==3.0.2"  # Pybind11 version should be synced with find_package(pybind11 ...) in CMakeLists.txt
+]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -12,7 +15,7 @@ authors = [
     { name = "S. Junges", email = "sebastian.junges@ru.nl" },
     { name = "M. Volk", email = "m.volk@tue.nl" }
 ]
-requires-python = ">=3.10" # Also check CMakeLists.txt, in the line with find_package(Python
+requires-python = ">=3.10"  # Python version should be synced with find_package(Python ...) in CMakeLists.txt
 dependencies = [
     "Deprecated",
 ]
@@ -43,7 +46,7 @@ doc = [
     "nbsphinx",
     "ipython",
     "ipykernel",
-] # also requires pandoc to be installed
+]  # also requires pandoc to be installed
 dev = [
     # Formatting
     "black[jupyter]",
@@ -90,7 +93,7 @@ CARLPARSER_DIR_HINT=""
 COMPILE_WITH_CCACHE="ON"
 STORMPY_DISABLE_SIGNATURE_DOC="OFF"
 STORM_GIT_REPO="https://github.com/moves-rwth/storm.git"
-STORM_GIT_TAG="1.11.1"
+STORM_GIT_TAG="1.11.1"  # Storm version should be synced with STORM_MIN_VERSION in CMakeLists.txt
 
 
 [tool.scikit-build.metadata.version]


### PR DESCRIPTION
Enforce exact pybind11 version in CMake. This prevents issues with newer pybind versions before supporting them.

Also started to add some documentation on stormpy development.