### PR TITLE
CI: fixed regex for obtaining Storm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         id: getVersion
         run: |
           # Get Storm version from STORM_GIT_TAG in pyproject.toml
-          echo "STORM_VERSION=$(sed -n -E 's/STORM_GIT_TAG="(.+)"/\1/p' pyproject.toml)" >> "$GITHUB_OUTPUT"
+          echo "STORM_VERSION=$(sed -n -E 's/STORM_GIT_TAG="(.+)".*/\1/p' pyproject.toml)" >> "$GITHUB_OUTPUT"
 
   deploy_docker:
     # Create Docker images for tag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,8 @@ CARLPARSER_DIR_HINT=""
 COMPILE_WITH_CCACHE="ON"
 STORMPY_DISABLE_SIGNATURE_DOC="OFF"
 STORM_GIT_REPO="https://github.com/moves-rwth/storm.git"
-STORM_GIT_TAG="1.12.0"  # Storm version should be synced with STORM_MIN_VERSION in CMakeLists.txt
+# Storm version should be synced with STORM_MIN_VERSION in CMakeLists.txt
+STORM_GIT_TAG="1.12.0"
 
 
 [tool.scikit-build.metadata.version]


### PR DESCRIPTION
Double redundancies against the bug in the release workflow:
- removed the culprit comment after the Storm version
- fixed the regex such that parts after the match are ignored