### PR TITLE
Improved CI for creating wheels

### DIFF
--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -154,8 +154,6 @@ jobs:
     name: Test wheel on ${{ matrix.distro }} and ${{ matrix.arch.name }}
     needs: [build_wheels]
     runs-on: ${{ matrix.arch.runner }}
-    # Allow failure for development version because not all runners have the latest Python versions
-    continue-on-error: ${{ inputs.dev_version }}
     strategy:
       fail-fast: false
       matrix:
@@ -243,8 +241,6 @@ jobs:
     name: Test wheel on ${{ matrix.distro.name }}
     needs: [build_wheels]
     runs-on: ${{ matrix.distro.distro }}
-    # Allow failure for development version because not all runners have the latest Python version
-    continue-on-error: ${{ inputs.dev_version }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -19,6 +19,17 @@ on:
         required: true
         type: boolean
         default: false
+      repo:
+        description: 'Repository to build from (owner/name)'
+        required: false
+        type: string
+        default: ''
+      ref:
+        description: 'Git ref (branch/tag/commit)'
+        required: false
+        type: string
+        default: ''
+
   # needed to trigger the workflow manually
   workflow_dispatch:
     inputs:
@@ -37,6 +48,16 @@ on:
         required: true
         type: boolean
         default: false
+      repo:
+        description: 'Repository to build from (owner/name)'
+        required: false
+        type: string
+        default: ''
+      ref:
+        description: 'Git ref (branch/tag/commit)'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build_wheels:
@@ -67,10 +88,15 @@ jobs:
             deploy_target: 14.0
       fail-fast: false
     steps:
-      - name: Git clone
+      - name: Git clone (default current repo)
+        if: ${{ inputs.repo == '' }}
+        uses: actions/checkout@v6
+      - name: Git clone (custom repo)
+        if: ${{ inputs.repo != '' }}
         uses: actions/checkout@v6
         with:
-          repository: stormchecker/stormpy
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.ref }}
       - uses: maxim-lobanov/setup-xcode@v1
         if: ${{ matrix.xcode != '' }}
         with:
@@ -105,10 +131,15 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - name: Git clone
+      - name: Git clone (default current repo)
+        if: ${{ inputs.repo == '' }}
+        uses: actions/checkout@v6
+      - name: Git clone (custom repo)
+        if: ${{ inputs.repo != '' }}
         uses: actions/checkout@v6
         with:
-          repository: stormchecker/stormpy
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.ref }}
       - name: Prepare version
         run: perl -i -pe 's/__version__ = "[^"]+"/__version__ = "'"${{ inputs.version }}"'"/' lib/stormpy/_version.py
       - name: Build sdist
@@ -151,10 +182,19 @@ jobs:
           pattern: stormpy-wheels-${{ matrix.arch.name }}
           path: dist
           merge-multiple: true
-      - name: Checkout test files
+      - name: Checkout test files (default current repo)
+        if: ${{ inputs.repo == '' }}
         uses: actions/checkout@v6
         with:
-          repository: stormchecker/stormpy
+          path: dist/test_files
+          sparse-checkout: |
+            tests
+      - name: Checkout test files (custom repo)
+        if: ${{ inputs.repo != '' }}
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.ref }}
           path: dist/test_files
           sparse-checkout: |
             tests
@@ -250,10 +290,19 @@ jobs:
           python3 -m venv venv
           source venv/bin/activate
           python3 -m pip install "$WHEEL"
-      - name: Checkout test files
+      - name: Checkout test files (default current repo)
+        if: ${{ inputs.repo == '' }}
         uses: actions/checkout@v6
         with:
-          repository: stormchecker/stormpy
+          path: dist/test_files
+          sparse-checkout: |
+            tests
+      - name: Checkout test files (custom repo)
+        if: ${{ inputs.repo != '' }}
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.ref }}
           path: dist/test_files
           sparse-checkout: |
             tests


### PR DESCRIPTION
- added optional inputs `repo` and `ref`. By default the current repo is used, but a custom repo is used for example in the nightly wheel generation in [stormchecker/stormpy-wheels](https://github.com/stormchecker/stormpy-wheels)
- failures are not ignored in development version anymore