### PR TITLE
Fixed wheel generation

### DIFF
--- a/.github/workflows/before-all-linux.sh
+++ b/.github/workflows/before-all-linux.sh
@@ -6,7 +6,7 @@ set -e -u
 
 ginac_version=1.8.10
 
-dnf install -y boost-devel cln-devel gmp-devel glpk-devel hwloc-devel z3-devel xerces-c-devel eigen3-devel # missing ginac
+dnf install -y boost-devel cln-devel glpk-devel gmp-devel hwloc-devel libarchive-devel xerces-c-devel z3-devel eigen3-devel # missing ginac-devel
 
 cd /tmp
 

--- a/.github/workflows/before-all-macos.sh
+++ b/.github/workflows/before-all-macos.sh
@@ -4,7 +4,7 @@
 
 set -e -u
 
-brew install ccache automake boost cln ginac glpk hwloc z3 xerces-c
+brew install ccache automake boost cln ginac glpk gmp hwloc libarchive xerces-c z3
 
 # Install Storm
 git clone https://github.com/stormchecker/storm.git -b ${STORM_VERSION}

--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -63,7 +63,7 @@ jobs:
             deploy_target: 15.0
           - os: macos-arm
             runs-on: macos-14 # macos-14+ (including latest) are ARM64 runners
-            xcode: latest-stable
+            xcode: 15.4
             deploy_target: 14.0
       fail-fast: false
     steps:


### PR DESCRIPTION
The wheel generation for the latest release 1.13.1 was not successfull. This PR should fix it.
- added missing dependency libarchive
- also use XCode version 15.4 instead of latest-stable now because the latter lead to compile issues.