### PR TITLE
Use template in more places for ValueType

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -115,68 +115,71 @@ std::shared_ptr<storm::models::symbolic::Model<DdType, ValueType>> buildSymbolic
     }
 }
 
+template<typename ValueType>
+void define_build_sparse_model_defs(py::module& m) {
+    std::string type;
+    std::string desc;
+    if constexpr (std::is_same_v<ValueType, double>) { type = ""; desc = ""; }
+    else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) { type = "exact_"; desc = ""; }
+    else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) { type = "parametric_"; desc = "parametric "; }
+    else if constexpr (std::is_same_v<ValueType, storm::Interval>) { type = "interval_"; desc = "interval "; }
+    else if constexpr (std::is_same_v<ValueType, storm::RationalInterval>) { type = "exact_interval_"; desc = "exact interval "; }
+
+    m.def(("_build_sparse_" + type + "model_from_symbolic_description").c_str(), &buildSparseModel<ValueType>,
+          ("Build the " + desc + "model in sparse representation" +
+           (std::is_same_v<ValueType, storm::RationalNumber> ? " with exact number representation" : ""))
+              .c_str(),
+          py::arg("model_description"), py::arg("formulas") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
+    m.def(("build_sparse_" + type + "model_with_options").c_str(), &buildSparseModelWithOptions<ValueType>,
+          ("Build the " + desc + "model in sparse representation" +
+           (std::is_same_v<ValueType, storm::RationalNumber> ? " with exact number representation" : ""))
+              .c_str(),
+          py::arg("model_description"), py::arg("options"));
+    m.def(("_build_sparse_" + type + "model_from_drn").c_str(), &storm::api::buildExplicitDRNModel<ValueType>,
+          ("Build the " + desc + "model from DRN" +
+           (std::is_same_v<ValueType, storm::RationalFunction> ? " (parametric)" : ""))
+              .c_str(),
+          py::arg("file"), py::arg("options") = storm::parser::DirectEncodingParserOptions());
+
+    if constexpr (std::is_same_v<ValueType, double>) {
+        m.def("_build_symbolic_model_from_symbolic_description", &buildSymbolicModel<storm::dd::DdType::Sylvan, double>,
+              "Build the model in symbolic representation", py::arg("model_description"),
+              py::arg("formulas") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
+        m.def("build_sparse_model_from_explicit", &storm::api::buildExplicitModel<double>, "Build the model model from explicit input",
+              py::arg("transition_file"), py::arg("labeling_file"), py::arg("state_reward_file") = "", py::arg("transition_reward_file") = "",
+              py::arg("choice_labeling_file") = "");
+        m.def("make_sparse_model_builder", &storm::api::makeExplicitModelBuilder<double>, "Construct a builder instance", py::arg("model_description"),
+              py::arg("options"), py::arg("action_mask") = nullptr);
+        py::class_<storm::builder::ExplicitModelBuilder<double>>(m, "ExplicitModelBuilder", "Model builder for sparse models")
+            .def("build", &storm::builder::ExplicitModelBuilder<double>::build, "Build the model", py::call_guard<py::gil_scoped_release>())
+            .def("export_lookup", &storm::builder::ExplicitModelBuilder<double>::exportExplicitStateLookup, "Export a lookup model");
+    } else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) {
+        m.def("_build_symbolic_parametric_model_from_symbolic_description",
+              &buildSymbolicModel<storm::dd::DdType::Sylvan, storm::RationalFunction>, "Build the parametric model in symbolic representation",
+              py::arg("model_description"), py::arg("formulas") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
+        m.def("make_sparse_model_builder_parametric", &storm::api::makeExplicitModelBuilder<storm::RationalFunction>, "Construct a builder instance",
+              py::arg("model_description"), py::arg("options"), py::arg("action_mask") = nullptr);
+        py::class_<storm::builder::ExplicitModelBuilder<storm::RationalFunction>>(m, "ExplicitParametricModelBuilder", "Model builder for sparse models")
+            .def("build", &storm::builder::ExplicitModelBuilder<storm::RationalFunction>::build, "Build the model",
+                 py::call_guard<py::gil_scoped_release>())
+            .def("export_lookup", &storm::builder::ExplicitModelBuilder<storm::RationalFunction>::exportExplicitStateLookup, "Export a lookup model");
+    } else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) {
+        m.def("make_sparse_model_builder_exact", &storm::api::makeExplicitModelBuilder<storm::RationalNumber>, "Construct a builder instance",
+              py::arg("model_description"), py::arg("options"), py::arg("action_mask") = nullptr);
+    }
+}
+
 void define_build(py::module& m) {
     py::class_<storm::parser::DirectEncodingParserOptions>(m, "DirectEncodingParserOptions", "Options for the .drn parser")
         .def(py::init<>(), "initialise")
         .def_readwrite("build_choice_labels", &storm::parser::DirectEncodingParserOptions::buildChoiceLabeling, "Build with choice labels");
 
     // Build model
-    m.def("_build_sparse_model_from_symbolic_description", &buildSparseModel<double>, "Build the model in sparse representation", py::arg("model_description"),
-          py::arg("formulas") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
-    m.def("_build_sparse_exact_model_from_symbolic_description", &buildSparseModel<storm::RationalNumber>,
-          "Build the model in sparse representation with exact number representation", py::arg("model_description"),
-          py::arg("formulas") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
-    m.def("_build_sparse_parametric_model_from_symbolic_description", &buildSparseModel<storm::RationalFunction>,
-          "Build the parametric model in sparse representation", py::arg("model_description"),
-          py::arg("formulas") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
-    m.def("_build_sparse_interval_model_from_symbolic_description", &buildSparseModel<storm::Interval>, "Build the interval model in sparse representation",
-          py::arg("model_description"), py::arg("formulas") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
-    m.def("_build_sparse_exact_interval_model_from_symbolic_description", &buildSparseModel<storm::RationalInterval>,
-          "Build the exact interval model in sparse representation", py::arg("model_description"),
-          py::arg("formulas") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
-    m.def("build_sparse_model_with_options", &buildSparseModelWithOptions<double>, "Build the model in sparse representation", py::arg("model_description"),
-          py::arg("options"));
-    m.def("build_sparse_exact_model_with_options", &buildSparseModelWithOptions<storm::RationalNumber>,
-          "Build the model in sparse representation with exact number representation", py::arg("model_description"), py::arg("options"));
-    m.def("build_sparse_parametric_model_with_options", &buildSparseModelWithOptions<storm::RationalFunction>, "Build the model in sparse representation",
-          py::arg("model_description"), py::arg("options"));
-    m.def("build_sparse_interval_model_with_options", &buildSparseModelWithOptions<storm::Interval>, "Build the interval model in sparse representation",
-          py::arg("model_description"), py::arg("options"));
-    m.def("build_sparse_exact_interval_model_with_options", &buildSparseModelWithOptions<storm::RationalInterval>,
-          "Build the exact interval model in sparse representation", py::arg("model_description"), py::arg("options"));
-    m.def("_build_symbolic_model_from_symbolic_description", &buildSymbolicModel<storm::dd::DdType::Sylvan, double>,
-          "Build the model in symbolic representation", py::arg("model_description"),
-          py::arg("formulas") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
-    m.def("_build_symbolic_parametric_model_from_symbolic_description", &buildSymbolicModel<storm::dd::DdType::Sylvan, storm::RationalFunction>,
-          "Build the parametric model in symbolic representation", py::arg("model_description"),
-          py::arg("formulas") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
-    m.def("_build_sparse_model_from_drn", &storm::api::buildExplicitDRNModel<double>, "Build the model from DRN", py::arg("file"),
-          py::arg("options") = storm::parser::DirectEncodingParserOptions());
-    m.def("_build_sparse_exact_model_from_drn", &storm::api::buildExplicitDRNModel<storm::RationalNumber>, "Build the model from DRN", py::arg("file"),
-          py::arg("options") = storm::parser::DirectEncodingParserOptions());
-    m.def("_build_sparse_parametric_model_from_drn", &storm::api::buildExplicitDRNModel<storm::RationalFunction>, "Build the parametric model from DRN",
-          py::arg("file"), py::arg("options") = storm::parser::DirectEncodingParserOptions());
-    m.def("_build_sparse_interval_model_from_drn", &storm::api::buildExplicitDRNModel<storm::Interval>, "Build the interval model from DRN", py::arg("file"),
-          py::arg("options") = storm::parser::DirectEncodingParserOptions());
-    m.def("_build_sparse_exact_interval_model_from_drn", &storm::api::buildExplicitDRNModel<storm::RationalInterval>, "Build the exact interval model from DRN",
-          py::arg("file"), py::arg("options") = storm::parser::DirectEncodingParserOptions());
-    m.def("build_sparse_model_from_explicit", &storm::api::buildExplicitModel<double>, "Build the model model from explicit input", py::arg("transition_file"),
-          py::arg("labeling_file"), py::arg("state_reward_file") = "", py::arg("transition_reward_file") = "", py::arg("choice_labeling_file") = "");
-
-    m.def("make_sparse_model_builder", &storm::api::makeExplicitModelBuilder<double>, "Construct a builder instance", py::arg("model_description"),
-          py::arg("options"), py::arg("action_mask") = nullptr);
-    m.def("make_sparse_model_builder_exact", &storm::api::makeExplicitModelBuilder<storm::RationalNumber>, "Construct a builder instance",
-          py::arg("model_description"), py::arg("options"), py::arg("action_mask") = nullptr);
-    m.def("make_sparse_model_builder_parametric", &storm::api::makeExplicitModelBuilder<storm::RationalFunction>, "Construct a builder instance",
-          py::arg("model_description"), py::arg("options"), py::arg("action_mask") = nullptr);
-
-    py::class_<storm::builder::ExplicitModelBuilder<double>>(m, "ExplicitModelBuilder", "Model builder for sparse models")
-        .def("build", &storm::builder::ExplicitModelBuilder<double>::build, "Build the model", py::call_guard<py::gil_scoped_release>())
-        .def("export_lookup", &storm::builder::ExplicitModelBuilder<double>::exportExplicitStateLookup, "Export a lookup model");
-
-    py::class_<storm::builder::ExplicitModelBuilder<storm::RationalFunction>>(m, "ExplicitParametricModelBuilder", "Model builder for sparse models")
-        .def("build", &storm::builder::ExplicitModelBuilder<storm::RationalFunction>::build, "Build the model", py::call_guard<py::gil_scoped_release>())
-        .def("export_lookup", &storm::builder::ExplicitModelBuilder<storm::RationalFunction>::exportExplicitStateLookup, "Export a lookup model");
+    define_build_sparse_model_defs<double>(m);
+    define_build_sparse_model_defs<storm::RationalNumber>(m);
+    define_build_sparse_model_defs<storm::RationalFunction>(m);
+    define_build_sparse_model_defs<storm::Interval>(m);
+    define_build_sparse_model_defs<storm::RationalInterval>(m);
 
     py::class_<storm::builder::ExplicitStateLookup<uint32_t>>(m, "ExplicitStateLookup", "Lookup model for states")
         .def(
@@ -240,6 +243,21 @@ void exportDRN(std::shared_ptr<storm::models::sparse::Model<ValueType>> model, s
     storm::api::exportSparseModelAsDrn<ValueType>(model, file, options);
 }
 
+template<typename ValueType>
+void define_export_drn(py::module& m) {
+    std::string prefix;
+    std::string suffix;
+    if constexpr (std::is_same_v<ValueType, double>) { prefix = ""; suffix = ""; }
+    else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) { prefix = "_exact"; suffix = ""; }
+    else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) { prefix = "_parametric"; suffix = ""; }
+    else if constexpr (std::is_same_v<ValueType, storm::Interval>) { prefix = ""; suffix = "_interval"; }
+    else if constexpr (std::is_same_v<ValueType, storm::RationalInterval>) { prefix = "_exact"; suffix = "_interval"; }
+
+    m.def(("_export" + prefix + "_to_drn" + suffix).c_str(), &exportDRN<ValueType>,
+          ("Export " + (std::is_same_v<ValueType, storm::RationalFunction> ? std::string("parametric ") : std::string()) + "model in DRN format").c_str(),
+          py::arg("model"), py::arg("file"), py::arg("options") = storm::io::DirectEncodingExporterOptions());
+}
+
 void define_export(py::module& m) {
     py::class_<storm::io::DirectEncodingExporterOptions>(m, "DirectEncodingExporterOptions")
         .def(py::init<>())
@@ -247,14 +265,9 @@ void define_export(py::module& m) {
         .def_readwrite("outputPrecision", &storm::io::DirectEncodingExporterOptions::outputPrecision);
 
     // Export
-    m.def("_export_to_drn", &exportDRN<double>, "Export model in DRN format", py::arg("model"), py::arg("file"),
-          py::arg("options") = storm::io::DirectEncodingExporterOptions());
-    m.def("_export_to_drn_interval", &exportDRN<storm::Interval>, "Export model in DRN format", py::arg("model"), py::arg("file"),
-          py::arg("options") = storm::io::DirectEncodingExporterOptions());
-    m.def("_export_exact_to_drn_interval", &exportDRN<storm::RationalInterval>, "Export model in DRN format", py::arg("model"), py::arg("file"),
-          py::arg("options") = storm::io::DirectEncodingExporterOptions());
-    m.def("_export_exact_to_drn", &exportDRN<storm::RationalNumber>, "Export model in DRN format", py::arg("model"), py::arg("file"),
-          py::arg("options") = storm::io::DirectEncodingExporterOptions());
-    m.def("_export_parametric_to_drn", &exportDRN<storm::RationalFunction>, "Export parametric model in DRN format", py::arg("model"), py::arg("file"),
-          py::arg("options") = storm::io::DirectEncodingExporterOptions());
+    define_export_drn<double>(m);
+    define_export_drn<storm::Interval>(m);
+    define_export_drn<storm::RationalInterval>(m);
+    define_export_drn<storm::RationalNumber>(m);
+    define_export_drn<storm::RationalFunction>(m);
 }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -119,27 +119,36 @@ template<typename ValueType>
 void define_build_sparse_model_defs(py::module& m) {
     std::string type;
     std::string desc;
-    if constexpr (std::is_same_v<ValueType, double>) { type = ""; desc = ""; }
-    else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) { type = "exact_"; desc = ""; }
-    else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) { type = "parametric_"; desc = "parametric "; }
-    else if constexpr (std::is_same_v<ValueType, storm::Interval>) { type = "interval_"; desc = "interval "; }
-    else if constexpr (std::is_same_v<ValueType, storm::RationalInterval>) { type = "exact_interval_"; desc = "exact interval "; }
+    if constexpr (std::is_same_v<ValueType, double>) {
+        type = "";
+        desc = "";
+    } else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) {
+        type = "exact_";
+        desc = "";
+    } else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) {
+        type = "parametric_";
+        desc = "parametric ";
+    } else if constexpr (std::is_same_v<ValueType, storm::Interval>) {
+        type = "interval_";
+        desc = "interval ";
+    } else if constexpr (std::is_same_v<ValueType, storm::RationalInterval>) {
+        type = "exact_interval_";
+        desc = "exact interval ";
+    }
 
-    m.def(("_build_sparse_" + type + "model_from_symbolic_description").c_str(), &buildSparseModel<ValueType>,
-          ("Build the " + desc + "model in sparse representation" +
-           (std::is_same_v<ValueType, storm::RationalNumber> ? " with exact number representation" : ""))
-              .c_str(),
-          py::arg("model_description"), py::arg("formulas") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
-    m.def(("build_sparse_" + type + "model_with_options").c_str(), &buildSparseModelWithOptions<ValueType>,
-          ("Build the " + desc + "model in sparse representation" +
-           (std::is_same_v<ValueType, storm::RationalNumber> ? " with exact number representation" : ""))
-              .c_str(),
-          py::arg("model_description"), py::arg("options"));
+    m.def(
+        ("_build_sparse_" + type + "model_from_symbolic_description").c_str(), &buildSparseModel<ValueType>,
+        ("Build the " + desc + "model in sparse representation" + (std::is_same_v<ValueType, storm::RationalNumber> ? " with exact number representation" : ""))
+            .c_str(),
+        py::arg("model_description"), py::arg("formulas") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
+    m.def(
+        ("build_sparse_" + type + "model_with_options").c_str(), &buildSparseModelWithOptions<ValueType>,
+        ("Build the " + desc + "model in sparse representation" + (std::is_same_v<ValueType, storm::RationalNumber> ? " with exact number representation" : ""))
+            .c_str(),
+        py::arg("model_description"), py::arg("options"));
     m.def(("_build_sparse_" + type + "model_from_drn").c_str(), &storm::api::buildExplicitDRNModel<ValueType>,
-          ("Build the " + desc + "model from DRN" +
-           (std::is_same_v<ValueType, storm::RationalFunction> ? " (parametric)" : ""))
-              .c_str(),
-          py::arg("file"), py::arg("options") = storm::parser::DirectEncodingParserOptions());
+          ("Build the " + desc + "model from DRN" + (std::is_same_v<ValueType, storm::RationalFunction> ? " (parametric)" : "")).c_str(), py::arg("file"),
+          py::arg("options") = storm::parser::DirectEncodingParserOptions());
 
     if constexpr (std::is_same_v<ValueType, double>) {
         m.def("_build_symbolic_model_from_symbolic_description", &buildSymbolicModel<storm::dd::DdType::Sylvan, double>,
@@ -154,14 +163,13 @@ void define_build_sparse_model_defs(py::module& m) {
             .def("build", &storm::builder::ExplicitModelBuilder<double>::build, "Build the model", py::call_guard<py::gil_scoped_release>())
             .def("export_lookup", &storm::builder::ExplicitModelBuilder<double>::exportExplicitStateLookup, "Export a lookup model");
     } else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) {
-        m.def("_build_symbolic_parametric_model_from_symbolic_description",
-              &buildSymbolicModel<storm::dd::DdType::Sylvan, storm::RationalFunction>, "Build the parametric model in symbolic representation",
-              py::arg("model_description"), py::arg("formulas") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
+        m.def("_build_symbolic_parametric_model_from_symbolic_description", &buildSymbolicModel<storm::dd::DdType::Sylvan, storm::RationalFunction>,
+              "Build the parametric model in symbolic representation", py::arg("model_description"),
+              py::arg("formulas") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
         m.def("make_sparse_model_builder_parametric", &storm::api::makeExplicitModelBuilder<storm::RationalFunction>, "Construct a builder instance",
               py::arg("model_description"), py::arg("options"), py::arg("action_mask") = nullptr);
         py::class_<storm::builder::ExplicitModelBuilder<storm::RationalFunction>>(m, "ExplicitParametricModelBuilder", "Model builder for sparse models")
-            .def("build", &storm::builder::ExplicitModelBuilder<storm::RationalFunction>::build, "Build the model",
-                 py::call_guard<py::gil_scoped_release>())
+            .def("build", &storm::builder::ExplicitModelBuilder<storm::RationalFunction>::build, "Build the model", py::call_guard<py::gil_scoped_release>())
             .def("export_lookup", &storm::builder::ExplicitModelBuilder<storm::RationalFunction>::exportExplicitStateLookup, "Export a lookup model");
     } else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) {
         m.def("make_sparse_model_builder_exact", &storm::api::makeExplicitModelBuilder<storm::RationalNumber>, "Construct a builder instance",
@@ -247,11 +255,22 @@ template<typename ValueType>
 void define_export_drn(py::module& m) {
     std::string prefix;
     std::string suffix;
-    if constexpr (std::is_same_v<ValueType, double>) { prefix = ""; suffix = ""; }
-    else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) { prefix = "_exact"; suffix = ""; }
-    else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) { prefix = "_parametric"; suffix = ""; }
-    else if constexpr (std::is_same_v<ValueType, storm::Interval>) { prefix = ""; suffix = "_interval"; }
-    else if constexpr (std::is_same_v<ValueType, storm::RationalInterval>) { prefix = "_exact"; suffix = "_interval"; }
+    if constexpr (std::is_same_v<ValueType, double>) {
+        prefix = "";
+        suffix = "";
+    } else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) {
+        prefix = "_exact";
+        suffix = "";
+    } else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) {
+        prefix = "_parametric";
+        suffix = "";
+    } else if constexpr (std::is_same_v<ValueType, storm::Interval>) {
+        prefix = "";
+        suffix = "_interval";
+    } else if constexpr (std::is_same_v<ValueType, storm::RationalInterval>) {
+        prefix = "_exact";
+        suffix = "_interval";
+    }
 
     m.def(("_export" + prefix + "_to_drn" + suffix).c_str(), &exportDRN<ValueType>,
           ("Export " + (std::is_same_v<ValueType, storm::RationalFunction> ? std::string("parametric ") : std::string()) + "model in DRN format").c_str(),

--- a/src/core/modelchecking.cpp
+++ b/src/core/modelchecking.cpp
@@ -169,7 +169,8 @@ void define_modelchecking_mdefs(py::module& m) {
               py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
         m.def("_model_checking_hybrid_engine", &modelCheckingHybridEngine<storm::dd::DdType::Sylvan, double>, "Perform model checking using the hybrid engine",
               py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
-        m.def("_compute_prob01states_double", &computeProb01<double>, "Compute prob-0-1 states", py::arg("model"), py::arg("phi_states"), py::arg("psi_states"));
+        m.def("_compute_prob01states_double", &computeProb01<double>, "Compute prob-0-1 states", py::arg("model"), py::arg("phi_states"),
+              py::arg("psi_states"));
         m.def("_compute_prob01states_min_double", &computeProb01min<double>, "Compute prob-0-1 states (min)", py::arg("model"), py::arg("phi_states"),
               py::arg("psi_states"));
         m.def("_compute_prob01states_max_double", &computeProb01max<double>, "Compute prob-0-1 states (max)", py::arg("model"), py::arg("phi_states"),
@@ -185,8 +186,8 @@ void define_modelchecking_mdefs(py::module& m) {
               py::arg("environment") = storm::Environment());
         m.def("_exact_model_checking_sparse_engine", &modelCheckingSparseEngine<storm::RationalNumber>, "Perform model checking using the sparse engine",
               py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
-        m.def("_multi_objective_model_checking_exact", &multiObjectiveModelChecking<storm::RationalNumber>, "Run multi-objective model checking", py::arg("model"),
-              py::arg("formula"), py::arg("environment") = storm::Environment());
+        m.def("_multi_objective_model_checking_exact", &multiObjectiveModelChecking<storm::RationalNumber>, "Run multi-objective model checking",
+              py::arg("model"), py::arg("formula"), py::arg("environment") = storm::Environment());
     } else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) {
         m.def("_get_reachable_states_rf", &getReachableStates<storm::RationalFunction>, py::arg("model"), py::arg("initial_states"),
               py::arg("constraint_states"), py::arg("target_states"), py::arg("maximal_steps") = boost::none, py::arg("choice_filter") = boost::none);

--- a/src/core/modelchecking.cpp
+++ b/src/core/modelchecking.cpp
@@ -154,6 +154,57 @@ void define_check_task(py::module& m, std::string const& name) {
              "Sets the mode which decides how the uncertainty will be resolved.");
 }
 
+template<typename ValueType>
+void define_modelchecking_mdefs(py::module& m) {
+    if constexpr (std::is_same_v<ValueType, double>) {
+        m.def("_get_reachable_states_double", &getReachableStates<double>, py::arg("model"), py::arg("initial_states"), py::arg("constraint_states"),
+              py::arg("target_states"), py::arg("maximal_steps") = boost::none, py::arg("choice_filter") = boost::none);
+        m.def("_compute_expected_number_of_visits_double", &getExpectedNumberOfVisits<double>, py::arg("env"), py::arg("model"));
+        m.def("_compute_steady_state_distribution_double", &getSteadyStateDistribution<double>, py::arg("env"), py::arg("model"));
+        m.def("_model_checking_fully_observable", &modelCheckingFullyObservableSparseEngine<double>, py::arg("model"), py::arg("task"),
+              py::arg("environment") = storm::Environment());
+        m.def("_model_checking_sparse_engine", &modelCheckingSparseEngine<double>, "Perform model checking using the sparse engine", py::arg("model"),
+              py::arg("task"), py::arg("environment") = storm::Environment());
+        m.def("_model_checking_dd_engine", &modelCheckingDdEngine<storm::dd::DdType::Sylvan, double>, "Perform model checking using the dd engine",
+              py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
+        m.def("_model_checking_hybrid_engine", &modelCheckingHybridEngine<storm::dd::DdType::Sylvan, double>, "Perform model checking using the hybrid engine",
+              py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
+        m.def("_compute_prob01states_double", &computeProb01<double>, "Compute prob-0-1 states", py::arg("model"), py::arg("phi_states"), py::arg("psi_states"));
+        m.def("_compute_prob01states_min_double", &computeProb01min<double>, "Compute prob-0-1 states (min)", py::arg("model"), py::arg("phi_states"),
+              py::arg("psi_states"));
+        m.def("_compute_prob01states_max_double", &computeProb01max<double>, "Compute prob-0-1 states (max)", py::arg("model"), py::arg("phi_states"),
+              py::arg("psi_states"));
+        m.def("_multi_objective_model_checking_double", &multiObjectiveModelChecking<double>, "Run multi-objective model checking", py::arg("model"),
+              py::arg("formula"), py::arg("environment") = storm::Environment());
+    } else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) {
+        m.def("_get_reachable_states_exact", &getReachableStates<storm::RationalNumber>, py::arg("model"), py::arg("initial_states"),
+              py::arg("constraint_states"), py::arg("target_states"), py::arg("maximal_steps") = boost::none, py::arg("choice_filter") = boost::none);
+        m.def("_compute_expected_number_of_visits_exact", &getExpectedNumberOfVisits<storm::RationalNumber>, py::arg("env"), py::arg("model"));
+        m.def("_compute_steady_state_distribution_exact", &getSteadyStateDistribution<storm::RationalNumber>, py::arg("env"), py::arg("model"));
+        m.def("_exact_model_checking_fully_observable", &modelCheckingFullyObservableSparseEngine<storm::RationalNumber>, py::arg("model"), py::arg("task"),
+              py::arg("environment") = storm::Environment());
+        m.def("_exact_model_checking_sparse_engine", &modelCheckingSparseEngine<storm::RationalNumber>, "Perform model checking using the sparse engine",
+              py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
+        m.def("_multi_objective_model_checking_exact", &multiObjectiveModelChecking<storm::RationalNumber>, "Run multi-objective model checking", py::arg("model"),
+              py::arg("formula"), py::arg("environment") = storm::Environment());
+    } else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) {
+        m.def("_get_reachable_states_rf", &getReachableStates<storm::RationalFunction>, py::arg("model"), py::arg("initial_states"),
+              py::arg("constraint_states"), py::arg("target_states"), py::arg("maximal_steps") = boost::none, py::arg("choice_filter") = boost::none);
+        m.def("_parametric_model_checking_sparse_engine", &modelCheckingSparseEngine<storm::RationalFunction>,
+              "Perform parametric model checking using the sparse engine", py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
+        m.def("_parametric_model_checking_dd_engine", &modelCheckingDdEngine<storm::dd::DdType::Sylvan, storm::RationalFunction>,
+              "Perform parametric model checking using the dd engine", py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
+        m.def("_parametric_model_checking_hybrid_engine", &modelCheckingHybridEngine<storm::dd::DdType::Sylvan, storm::RationalFunction>,
+              "Perform parametric model checking using the hybrid engine", py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
+        m.def("_compute_prob01states_rationalfunc", &computeProb01<storm::RationalFunction>, "Compute prob-0-1 states", py::arg("model"), py::arg("phi_states"),
+              py::arg("psi_states"));
+        m.def("_compute_prob01states_min_rationalfunc", &computeProb01min<storm::RationalFunction>, "Compute prob-0-1 states (min)", py::arg("model"),
+              py::arg("phi_states"), py::arg("psi_states"));
+        m.def("_compute_prob01states_max_rationalfunc", &computeProb01max<storm::RationalFunction>, "Compute prob-0-1 states (max)", py::arg("model"),
+              py::arg("phi_states"), py::arg("psi_states"));
+    }
+}
+
 void define_modelchecking(py::module& m) {
     py::class_<storm::modelchecker::ModelCheckerHint, std::shared_ptr<storm::modelchecker::ModelCheckerHint>> mchint(
         m, "ModelCheckerHint", "Information that may accelerate the model checking process");
@@ -171,59 +222,16 @@ void define_modelchecking(py::module& m) {
              py::overload_cast<boost::optional<std::vector<double>> const&>(&storm::modelchecker::ExplicitModelCheckerHint<double>::setResultHint),
              "result_hint"_a);
 
-    m.def("_get_reachable_states_double", &getReachableStates<double>, py::arg("model"), py::arg("initial_states"), py::arg("constraint_states"),
-          py::arg("target_states"), py::arg("maximal_steps") = boost::none, py::arg("choice_filter") = boost::none);
-    m.def("_get_reachable_states_exact", &getReachableStates<storm::RationalNumber>, py::arg("model"), py::arg("initial_states"), py::arg("constraint_states"),
-          py::arg("target_states"), py::arg("maximal_steps") = boost::none, py::arg("choice_filter") = boost::none);
-    m.def("_get_reachable_states_rf", &getReachableStates<storm::RationalFunction>, py::arg("model"), py::arg("initial_states"), py::arg("constraint_states"),
-          py::arg("target_states"), py::arg("maximal_steps") = boost::none, py::arg("choice_filter") = boost::none);
+    define_modelchecking_mdefs<double>(m);
+    define_modelchecking_mdefs<storm::RationalNumber>(m);
+    define_modelchecking_mdefs<storm::RationalFunction>(m);
 
-    m.def("_compute_expected_number_of_visits_double", &getExpectedNumberOfVisits<double>, py::arg("env"), py::arg("model"));
-    m.def("_compute_expected_number_of_visits_exact", &getExpectedNumberOfVisits<storm::RationalNumber>, py::arg("env"), py::arg("model"));
-
-    m.def("_compute_steady_state_distribution_double", &getSteadyStateDistribution<double>, py::arg("env"), py::arg("model"));
-    m.def("_compute_steady_state_distribution_exact", &getSteadyStateDistribution<storm::RationalNumber>, py::arg("env"), py::arg("model"));
-
-    // Model checking
-    m.def("_model_checking_fully_observable", &modelCheckingFullyObservableSparseEngine<double>, py::arg("model"), py::arg("task"),
-          py::arg("environment") = storm::Environment());
-    m.def("_exact_model_checking_fully_observable", &modelCheckingFullyObservableSparseEngine<storm::RationalNumber>, py::arg("model"), py::arg("task"),
-          py::arg("environment") = storm::Environment());
-    m.def("_model_checking_sparse_engine", &modelCheckingSparseEngine<double>, "Perform model checking using the sparse engine", py::arg("model"),
-          py::arg("task"), py::arg("environment") = storm::Environment());
-    m.def("_exact_model_checking_sparse_engine", &modelCheckingSparseEngine<storm::RationalNumber>, "Perform model checking using the sparse engine",
-          py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
-    m.def("_parametric_model_checking_sparse_engine", &modelCheckingSparseEngine<storm::RationalFunction>,
-          "Perform parametric model checking using the sparse engine", py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
-    m.def("_model_checking_dd_engine", &modelCheckingDdEngine<storm::dd::DdType::Sylvan, double>, "Perform model checking using the dd engine",
-          py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
-    m.def("_parametric_model_checking_dd_engine", &modelCheckingDdEngine<storm::dd::DdType::Sylvan, storm::RationalFunction>,
-          "Perform parametric model checking using the dd engine", py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
-    m.def("_model_checking_hybrid_engine", &modelCheckingHybridEngine<storm::dd::DdType::Sylvan, double>, "Perform model checking using the hybrid engine",
-          py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
-    m.def("_parametric_model_checking_hybrid_engine", &modelCheckingHybridEngine<storm::dd::DdType::Sylvan, storm::RationalFunction>,
-          "Perform parametric model checking using the hybrid engine", py::arg("model"), py::arg("task"), py::arg("environment") = storm::Environment());
     m.def("check_interval_dtmc", &checkIntervalDtmc, "Check interval DTMC");
     m.def("check_exact_interval_dtmc", &checkRationalIntervalDtmc, "Check exact interval DTMC");
     m.def("check_interval_mdp", &checkIntervalMdp, "Check interval MDP");
     m.def("check_exact_interval_mdp", &checkRationalIntervalMdp, "Check exact interval MDP");
     m.def("compute_all_until_probabilities", &computeAllUntilProbabilities, "Compute forward until probabilities");
     m.def("compute_transient_probabilities", &computeTransientProbabilities, "Compute transient probabilities");
-    m.def("_compute_prob01states_double", &computeProb01<double>, "Compute prob-0-1 states", py::arg("model"), py::arg("phi_states"), py::arg("psi_states"));
-    m.def("_compute_prob01states_rationalfunc", &computeProb01<storm::RationalFunction>, "Compute prob-0-1 states", py::arg("model"), py::arg("phi_states"),
-          py::arg("psi_states"));
-    m.def("_compute_prob01states_min_double", &computeProb01min<double>, "Compute prob-0-1 states (min)", py::arg("model"), py::arg("phi_states"),
-          py::arg("psi_states"));
-    m.def("_compute_prob01states_max_double", &computeProb01max<double>, "Compute prob-0-1 states (max)", py::arg("model"), py::arg("phi_states"),
-          py::arg("psi_states"));
-    m.def("_compute_prob01states_min_rationalfunc", &computeProb01min<storm::RationalFunction>, "Compute prob-0-1 states (min)", py::arg("model"),
-          py::arg("phi_states"), py::arg("psi_states"));
-    m.def("_compute_prob01states_max_rationalfunc", &computeProb01max<storm::RationalFunction>, "Compute prob-0-1 states (max)", py::arg("model"),
-          py::arg("phi_states"), py::arg("psi_states"));
-    m.def("_multi_objective_model_checking_double", &multiObjectiveModelChecking<double>, "Run multi-objective model checking", py::arg("model"),
-          py::arg("formula"), py::arg("environment") = storm::Environment());
-    m.def("_multi_objective_model_checking_exact", &multiObjectiveModelChecking<storm::RationalNumber>, "Run multi-objective model checking", py::arg("model"),
-          py::arg("formula"), py::arg("environment") = storm::Environment());
 }
 
 template void define_check_task<double>(py::module&, std::string const&);

--- a/src/core/result.cpp
+++ b/src/core/result.cpp
@@ -26,11 +26,22 @@ std::shared_ptr<storm::modelchecker::QualitativeCheckResult> createFilterSymboli
     return std::make_unique<storm::modelchecker::SymbolicQualitativeCheckResult<DdType>>(model->getReachableStates(), model->getStates(expr));
 }
 
+template<typename ValueType>
+void define_result_as_explicit(py::class_<storm::modelchecker::CheckResult, std::shared_ptr<storm::modelchecker::CheckResult>>& checkResult,
+                               std::string const& vtSuffix) {
+    checkResult.def(("as_explicit" + vtSuffix + "_qualitative").c_str(),
+                    [](storm::modelchecker::CheckResult const& result) { return result.template asExplicitQualitativeCheckResult<ValueType>(); },
+                    "Convert into explicit qualitative result");
+    checkResult.def(("as_explicit" + vtSuffix + "_quantitative").c_str(),
+                    [](storm::modelchecker::CheckResult const& result) { return result.template asExplicitQuantitativeCheckResult<ValueType>(); },
+                    "Convert into explicit quantitative result");
+}
+
 // Define python bindings
 void define_result(py::module& m) {
     // CheckResult
     py::class_<storm::modelchecker::CheckResult, std::shared_ptr<storm::modelchecker::CheckResult>> checkResult(m, "_CheckResult",
-                                                                                                                "Base class for all modelchecking results");
+                                                                                                                 "Base class for all modelchecking results");
     checkResult.def_property_readonly("_symbolic", &storm::modelchecker::CheckResult::isSymbolic, "Flag if result is symbolic")
         .def_property_readonly("_hybrid", &storm::modelchecker::CheckResult::isHybrid, "Flag if result is hybrid")
         .def_property_readonly("_quantitative", &storm::modelchecker::CheckResult::isQuantitative, "Flag if result is quantitative")
@@ -48,29 +59,11 @@ void define_result(py::module& m) {
         .def_property_readonly("_pareto_curve", &storm::modelchecker::CheckResult::isParetoCurveCheckResult, "Flag if result is a pareto curve")
         .def_property_readonly("result_for_all_states", &storm::modelchecker::CheckResult::isResultForAllStates, "Flag if result is for all states")
         .def_property_readonly("has_scheduler", &storm::modelchecker::CheckResult::hasScheduler, "Flag if a scheduler is present")
-        .def(
-            "as_explicit_qualitative", [](storm::modelchecker::CheckResult const& result) { return result.asExplicitQualitativeCheckResult<double>(); },
-            "Convert into explicit qualitative result")
-        .def(
-            "as_explicit_exact_qualitative",
-            [](storm::modelchecker::CheckResult const& result) { return result.asExplicitQualitativeCheckResult<storm::RationalNumber>(); },
-            "Convert into explicit qualitative result")
-        .def(
-            "as_explicit_parametric_qualitative",
-            [](storm::modelchecker::CheckResult const& result) { return result.asExplicitQualitativeCheckResult<storm::RationalFunction>(); },
-            "Convert into explicit qualitative result")
-        .def(
-            "as_explicit_quantitative", [](storm::modelchecker::CheckResult const& result) { return result.asExplicitQuantitativeCheckResult<double>(); },
-            "Convert into explicit quantitative result")
-        .def(
-            "as_explicit_exact_quantitative",
-            [](storm::modelchecker::CheckResult const& result) { return result.asExplicitQuantitativeCheckResult<storm::RationalNumber>(); },
-            "Convert into explicit quantitative result")
-        .def(
-            "as_explicit_parametric_quantitative",
-            [](storm::modelchecker::CheckResult const& result) { return result.asExplicitQuantitativeCheckResult<storm::RationalFunction>(); },
-            "Convert into explicit quantitative result")
-        .def("filter", &storm::modelchecker::CheckResult::filter, py::arg("filter"), "Filter the result")
+        ;
+    define_result_as_explicit<double>(checkResult, "");
+    define_result_as_explicit<storm::RationalNumber>(checkResult, "_exact");
+    define_result_as_explicit<storm::RationalFunction>(checkResult, "_parametric");
+    checkResult.def("filter", &storm::modelchecker::CheckResult::filter, py::arg("filter"), "Filter the result")
         .def("__str__", [](storm::modelchecker::CheckResult const& result) {
             std::stringstream stream;
             result.writeToStream(stream);

--- a/src/core/result.cpp
+++ b/src/core/result.cpp
@@ -41,7 +41,7 @@ void define_result_as_explicit(py::class_<storm::modelchecker::CheckResult, std:
 void define_result(py::module& m) {
     // CheckResult
     py::class_<storm::modelchecker::CheckResult, std::shared_ptr<storm::modelchecker::CheckResult>> checkResult(m, "_CheckResult",
-                                                                                                                 "Base class for all modelchecking results");
+                                                                                                                "Base class for all modelchecking results");
     checkResult.def_property_readonly("_symbolic", &storm::modelchecker::CheckResult::isSymbolic, "Flag if result is symbolic")
         .def_property_readonly("_hybrid", &storm::modelchecker::CheckResult::isHybrid, "Flag if result is hybrid")
         .def_property_readonly("_quantitative", &storm::modelchecker::CheckResult::isQuantitative, "Flag if result is quantitative")
@@ -58,8 +58,7 @@ void define_result(py::module& m) {
                                "Flag if result is hybrid quantitative")
         .def_property_readonly("_pareto_curve", &storm::modelchecker::CheckResult::isParetoCurveCheckResult, "Flag if result is a pareto curve")
         .def_property_readonly("result_for_all_states", &storm::modelchecker::CheckResult::isResultForAllStates, "Flag if result is for all states")
-        .def_property_readonly("has_scheduler", &storm::modelchecker::CheckResult::hasScheduler, "Flag if a scheduler is present")
-        ;
+        .def_property_readonly("has_scheduler", &storm::modelchecker::CheckResult::hasScheduler, "Flag if a scheduler is present");
     define_result_as_explicit<double>(checkResult, "");
     define_result_as_explicit<storm::RationalNumber>(checkResult, "_exact");
     define_result_as_explicit<storm::RationalFunction>(checkResult, "_parametric");

--- a/src/core/transformation.cpp
+++ b/src/core/transformation.cpp
@@ -33,22 +33,22 @@ typename storm::transformer::EndComponentEliminator<ValueType>::EndComponentElim
 template<typename ValueType>
 void define_transformation_mdef(py::module& m) {
     std::string type, desc;
-    if constexpr (std::is_same_v<ValueType, double>) { type = ""; desc = ""; }
-    else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) { type = "_parametric"; desc = "parametric "; }
+    if constexpr (std::is_same_v<ValueType, double>) {
+        type = "";
+        desc = "";
+    } else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) {
+        type = "_parametric";
+        desc = "parametric ";
+    }
 
-    m.def(("_transform_to_sparse" + type + "_model").c_str(),
-          &storm::api::transformSymbolicToSparseModel<storm::dd::DdType::Sylvan, ValueType>,
-          ("Transform symbolic " + desc + "model into sparse " + desc + "model").c_str(),
-          py::arg("model"), py::arg("formulae") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
-    m.def(("_transform_to_discrete_time" + type + "_model").c_str(),
-          &transformContinuousToDiscreteTimeSparseModel<ValueType>,
-          ("Transform " + desc + "continuous time model to " + desc + "discrete time model").c_str(),
-          py::arg("model"),
+    m.def(("_transform_to_sparse" + type + "_model").c_str(), &storm::api::transformSymbolicToSparseModel<storm::dd::DdType::Sylvan, ValueType>,
+          ("Transform symbolic " + desc + "model into sparse " + desc + "model").c_str(), py::arg("model"),
           py::arg("formulae") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
-    m.def(("_eliminate_non_markovian_chains" + type).c_str(),
-          &storm::api::eliminateNonMarkovianChains<ValueType>,
-          "Eliminate chains of non-Markovian states in Markov automaton.",
-          py::arg("ma"), py::arg("formulae"), py::arg("label_behavior"));
+    m.def(("_transform_to_discrete_time" + type + "_model").c_str(), &transformContinuousToDiscreteTimeSparseModel<ValueType>,
+          ("Transform " + desc + "continuous time model to " + desc + "discrete time model").c_str(), py::arg("model"),
+          py::arg("formulae") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
+    m.def(("_eliminate_non_markovian_chains" + type).c_str(), &storm::api::eliminateNonMarkovianChains<ValueType>,
+          "Eliminate chains of non-Markovian states in Markov automaton.", py::arg("ma"), py::arg("formulae"), py::arg("label_behavior"));
 }
 
 void define_transformation(py::module& m) {

--- a/src/core/transformation.cpp
+++ b/src/core/transformation.cpp
@@ -30,19 +30,30 @@ typename storm::transformer::EndComponentEliminator<ValueType>::EndComponentElim
     return storm::transformer::EndComponentEliminator<ValueType>::transform(matrix, subsystemStates, possibleECRows, addSinkRowStates, addSelfLoopAtSinkStates);
 }
 
-void define_transformation(py::module& m) {
-    // Transform model
-    m.def("_transform_to_sparse_model", &storm::api::transformSymbolicToSparseModel<storm::dd::DdType::Sylvan, double>,
-          "Transform symbolic model into sparse model", py::arg("model"), py::arg("formulae") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
-    m.def("_transform_to_sparse_parametric_model", &storm::api::transformSymbolicToSparseModel<storm::dd::DdType::Sylvan, storm::RationalFunction>,
-          "Transform symbolic parametric model into sparse parametric model", py::arg("model"),
-          py::arg("formulae") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
+template<typename ValueType>
+void define_transformation_mdef(py::module& m) {
+    std::string type, desc;
+    if constexpr (std::is_same_v<ValueType, double>) { type = ""; desc = ""; }
+    else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) { type = "_parametric"; desc = "parametric "; }
 
-    m.def("_transform_to_discrete_time_model", &transformContinuousToDiscreteTimeSparseModel<double>, "Transform continuous time model to discrete time model",
+    m.def(("_transform_to_sparse" + type + "_model").c_str(),
+          &storm::api::transformSymbolicToSparseModel<storm::dd::DdType::Sylvan, ValueType>,
+          ("Transform symbolic " + desc + "model into sparse " + desc + "model").c_str(),
           py::arg("model"), py::arg("formulae") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
-    m.def("_transform_to_discrete_time_parametric_model", &transformContinuousToDiscreteTimeSparseModel<storm::RationalFunction>,
-          "Transform parametric continuous time model to parametric discrete time model", py::arg("model"),
+    m.def(("_transform_to_discrete_time" + type + "_model").c_str(),
+          &transformContinuousToDiscreteTimeSparseModel<ValueType>,
+          ("Transform " + desc + "continuous time model to " + desc + "discrete time model").c_str(),
+          py::arg("model"),
           py::arg("formulae") = std::vector<std::shared_ptr<storm::logic::Formula const>>());
+    m.def(("_eliminate_non_markovian_chains" + type).c_str(),
+          &storm::api::eliminateNonMarkovianChains<ValueType>,
+          "Eliminate chains of non-Markovian states in Markov automaton.",
+          py::arg("ma"), py::arg("formulae"), py::arg("label_behavior"));
+}
+
+void define_transformation(py::module& m) {
+    define_transformation_mdef<double>(m);
+    define_transformation_mdef<storm::RationalFunction>(m);
 
     py::class_<storm::transformer::SubsystemBuilderOptions>(m, "SubsystemBuilderOptions", "Options for constructing the subsystem")
         .def(py::init<>())
@@ -59,11 +70,6 @@ void define_transformation(py::module& m) {
         .value("MERGE_LABELS", storm::transformer::EliminationLabelBehavior::MergeLabels)
         .value("DELETE_LABELS", storm::transformer::EliminationLabelBehavior::DeleteLabels)
         .finalize();
-
-    m.def("_eliminate_non_markovian_chains", &storm::api::eliminateNonMarkovianChains<double>, "Eliminate chains of non-Markovian states in Markov automaton.",
-          py::arg("ma"), py::arg("formulae"), py::arg("label_behavior"));
-    m.def("_eliminate_non_markovian_chains_parametric", &storm::api::eliminateNonMarkovianChains<storm::RationalFunction>,
-          "Eliminate chains of non-Markovian states in Markov automaton.", py::arg("ma"), py::arg("formulae"), py::arg("label_behavior"));
 }
 
 template<typename ValueType>

--- a/src/mod_pars.cpp
+++ b/src/mod_pars.cpp
@@ -13,6 +13,8 @@ PYBIND11_MODULE(_pars, m) {
 
     define_pars(m);
     define_pla(m);
-    define_model_instantiator(m);
-    define_model_instantiation_checker(m);
+    define_model_instantiator<double>(m);
+    define_model_instantiator<storm::RationalFunction>(m);
+    define_model_instantiation_checker<double>(m);
+    define_model_instantiation_checker<storm::RationalNumber>(m);
 }

--- a/src/mod_storage.cpp
+++ b/src/mod_storage.cpp
@@ -30,7 +30,8 @@ PYBIND11_MODULE(_storage, m) {
 #endif
 
     define_bitvector(m);
-    define_dd<storm::dd::DdType::Sylvan>(m, "Sylvan");
+    auto ddSylvan = define_dd<storm::dd::DdType::Sylvan>(m, "Sylvan");
+    define_dd_typed<storm::dd::DdType::Sylvan, double>(m, "Sylvan", "_Double", ddSylvan);
     define_dd_nt(m);
     define_model(m);
     define_sparse_model<double>(m, "");

--- a/src/pars/model_instantiator.cpp
+++ b/src/pars/model_instantiator.cpp
@@ -42,17 +42,22 @@ void define_typed_instantiator(py::module& m, const char* pyName, const char* py
 template<typename ValueType>
 void define_model_instantiator(py::module& m) {
     std::string prefix;
-    if constexpr (std::is_same_v<ValueType, double>) { prefix = ""; }
-    else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) { prefix = "Partial"; }
+    if constexpr (std::is_same_v<ValueType, double>) {
+        prefix = "";
+    } else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) {
+        prefix = "Partial";
+    }
 
     define_typed_instantiator<Dtmc<storm::RationalFunction>, Dtmc<ValueType>>(m, (prefix + "PDtmcInstantiator").c_str(), "Instantiate PDTMCs to DTMCs");
     define_typed_instantiator<Mdp<storm::RationalFunction>, Mdp<ValueType>>(m, (prefix + "PMdpInstantiator").c_str(), "Instantiate PMDPs to MDPs");
     define_typed_instantiator<Ctmc<storm::RationalFunction>, Ctmc<ValueType>>(m, (prefix + "PCtmcInstantiator").c_str(), "Instantiate PCTMCs to CTMCs");
-    define_typed_instantiator<MarkovAutomaton<storm::RationalFunction>, MarkovAutomaton<ValueType>>(m, (prefix + "PMaInstantiator").c_str(), "Instantiate PMAs to MAs");
+    define_typed_instantiator<MarkovAutomaton<storm::RationalFunction>, MarkovAutomaton<ValueType>>(m, (prefix + "PMaInstantiator").c_str(),
+                                                                                                    "Instantiate PMAs to MAs");
 }
 
 // Trait: maps (ModelType, ResultType) to the specific checker class
-template<typename, typename> struct instantiation_checker;
+template<typename, typename>
+struct instantiation_checker;
 
 template<typename ResultType>
 struct instantiation_checker<Dtmc<storm::RationalFunction>, ResultType> {
@@ -74,45 +79,44 @@ template<typename ModelType, typename ResultType>
 void define_typed_checker(py::module& m, const char* baseName, const char* baseDesc, const char* derivedName, const char* derivedDesc) {
     using CheckerType = typename instantiation_checker<ModelType, ResultType>::type;
     using BaseChecker = SparseInstantiationModelChecker<ModelType, ResultType>;
-    auto base =
-        py::class_<BaseChecker, std::shared_ptr<BaseChecker>>(m, baseName, baseDesc);
+    auto base = py::class_<BaseChecker, std::shared_ptr<BaseChecker>>(m, baseName, baseDesc);
     base.def("specify_formula", &BaseChecker::specifyFormula, "check_task"_a);
 
     py::class_<CheckerType, std::shared_ptr<CheckerType>>(m, derivedName, derivedDesc, base)
         .def(py::init<ModelType>(), "parametric model"_a)
-        .def("check",
-             [](CheckerType& c, storm::Environment const& env,
-                storm::utility::parametric::Valuation<storm::RationalFunction> const& val) -> std::shared_ptr<CheckResult> { return c.check(env, val); },
-             "env"_a, "instantiation"_a)
+        .def(
+            "check",
+            [](CheckerType& c, storm::Environment const& env,
+               storm::utility::parametric::Valuation<storm::RationalFunction> const& val) -> std::shared_ptr<CheckResult> { return c.check(env, val); },
+            "env"_a, "instantiation"_a)
         .def("set_graph_preserving", &CheckerType::setInstantiationsAreGraphPreserving, "value"_a);
 }
 
 template<typename ValueType>
 void define_model_instantiation_checker(py::module& m) {
     std::string exactStr, exactDesc;
-    if constexpr (std::is_same_v<ValueType, double>) { exactStr = ""; exactDesc = ""; }
-    else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) { exactStr = "Exact"; exactDesc = "exact "; }
+    if constexpr (std::is_same_v<ValueType, double>) {
+        exactStr = "";
+        exactDesc = "";
+    } else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) {
+        exactStr = "Exact";
+        exactDesc = "exact ";
+    }
 
     // Dtmc
     define_typed_checker<Dtmc<storm::RationalFunction>, ValueType>(
-        m, ("_PDtmc" + exactStr + "InstantiationCheckerBase").c_str(),
-        ("Instantiate pDTMCs to " + exactDesc + "DTMCs and immediately check (base)").c_str(),
-        ("PDtmc" + exactStr + "InstantiationChecker").c_str(),
-        ("Instantiate pDTMCs to " + exactDesc + "DTMCs and immediately check").c_str());
+        m, ("_PDtmc" + exactStr + "InstantiationCheckerBase").c_str(), ("Instantiate pDTMCs to " + exactDesc + "DTMCs and immediately check (base)").c_str(),
+        ("PDtmc" + exactStr + "InstantiationChecker").c_str(), ("Instantiate pDTMCs to " + exactDesc + "DTMCs and immediately check").c_str());
 
     // Mdp
     define_typed_checker<Mdp<storm::RationalFunction>, ValueType>(
-        m, ("_PMdp" + exactStr + "InstantiationCheckerBase").c_str(),
-        ("Instantiate pMDPs to " + exactDesc + "MDPs and immediately check (base)").c_str(),
-        ("PMdp" + exactStr + "InstantiationChecker").c_str(),
-        ("Instantiate PMDP to " + exactDesc + "MDPs and immediately check").c_str());
+        m, ("_PMdp" + exactStr + "InstantiationCheckerBase").c_str(), ("Instantiate pMDPs to " + exactDesc + "MDPs and immediately check (base)").c_str(),
+        ("PMdp" + exactStr + "InstantiationChecker").c_str(), ("Instantiate PMDP to " + exactDesc + "MDPs and immediately check").c_str());
 
     // Ctmc
     define_typed_checker<Ctmc<storm::RationalFunction>, ValueType>(
-        m, ("_PCtmc" + exactStr + "InstantiationCheckerBase").c_str(),
-        ("Instantiate pCTMCs to " + exactDesc + "CTMCs and immediately check (base)").c_str(),
-        ("PCtmc" + exactStr + "InstantiationChecker").c_str(),
-        ("Instantiate pCTMCs to " + exactDesc + "CTMCs and immediately check").c_str());
+        m, ("_PCtmc" + exactStr + "InstantiationCheckerBase").c_str(), ("Instantiate pCTMCs to " + exactDesc + "CTMCs and immediately check (base)").c_str(),
+        ("PCtmc" + exactStr + "InstantiationChecker").c_str(), ("Instantiate pCTMCs to " + exactDesc + "CTMCs and immediately check").c_str());
 }
 
 template void define_model_instantiator<double>(py::module&);

--- a/src/pars/model_instantiator.cpp
+++ b/src/pars/model_instantiator.cpp
@@ -30,156 +30,92 @@ using MarkovAutomaton = storm::models::sparse::MarkovAutomaton<ValueType>;
 
 using namespace storm::modelchecker;
 
-// Model instantiator
+// Helper: define typed ModelInstantiator class
+template<typename ParametricModel, typename InstantiatedModel>
+void define_typed_instantiator(py::module& m, const char* pyName, const char* pyDesc) {
+    py::class_<storm::utility::ModelInstantiator<ParametricModel, InstantiatedModel>>(m, pyName, pyDesc)
+        .def(py::init<ParametricModel>(), "parametric model"_a)
+        .def("instantiate", &storm::utility::ModelInstantiator<ParametricModel, InstantiatedModel>::instantiate,
+             "Instantiate model with given parameter values");
+}
+
+template<typename ValueType>
 void define_model_instantiator(py::module& m) {
-    py::class_<storm::utility::ModelInstantiator<Dtmc<storm::RationalFunction>, Dtmc<double>>>(m, "PDtmcInstantiator", "Instantiate PDTMCs to DTMCs")
-        .def(py::init<Dtmc<storm::RationalFunction>>(), "parametric model"_a)
-        .def("instantiate", &storm::utility::ModelInstantiator<Dtmc<storm::RationalFunction>, Dtmc<double>>::instantiate,
-             "Instantiate model with given parameter values");
+    std::string prefix;
+    if constexpr (std::is_same_v<ValueType, double>) { prefix = ""; }
+    else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) { prefix = "Partial"; }
 
-    py::class_<storm::utility::ModelInstantiator<Mdp<storm::RationalFunction>, Mdp<double>>>(m, "PMdpInstantiator", "Instantiate PMDPs to MDPs")
-        .def(py::init<Mdp<storm::RationalFunction>>(), "parametric model"_a)
-        .def("instantiate", &storm::utility::ModelInstantiator<Mdp<storm::RationalFunction>, Mdp<double>>::instantiate,
-             "Instantiate model with given parameter values");
-
-    py::class_<storm::utility::ModelInstantiator<Ctmc<storm::RationalFunction>, Ctmc<double>>>(m, "PCtmcInstantiator", "Instantiate PCTMCs to CTMCs")
-        .def(py::init<Ctmc<storm::RationalFunction>>(), "parametric model"_a)
-        .def("instantiate", &storm::utility::ModelInstantiator<Ctmc<storm::RationalFunction>, Ctmc<double>>::instantiate,
-             "Instantiate model with given parameter values");
-
-    py::class_<storm::utility::ModelInstantiator<MarkovAutomaton<storm::RationalFunction>, MarkovAutomaton<double>>>(m, "PMaInstantiator",
-                                                                                                                     "Instantiate PMAs to MAs")
-        .def(py::init<MarkovAutomaton<storm::RationalFunction>>(), "parametric model"_a)
-        .def("instantiate", &storm::utility::ModelInstantiator<MarkovAutomaton<storm::RationalFunction>, MarkovAutomaton<double>>::instantiate,
-             "Instantiate model with given parameter values");
-
-    py::class_<storm::utility::ModelInstantiator<Dtmc<storm::RationalFunction>, Dtmc<storm::RationalFunction>>>(m, "PartialPDtmcInstantiator",
-                                                                                                                "Instantiate PDTMCs to DTMCs")
-        .def(py::init<Dtmc<storm::RationalFunction>>(), "parametric model"_a)
-        .def("instantiate", &storm::utility::ModelInstantiator<Dtmc<storm::RationalFunction>, Dtmc<storm::RationalFunction>>::instantiate,
-             "Instantiate model with given parameter values");
-
-    py::class_<storm::utility::ModelInstantiator<Mdp<storm::RationalFunction>, Mdp<storm::RationalFunction>>>(m, "PartialPMdpInstantiator",
-                                                                                                              "Instantiate PMDPs to MDPs")
-        .def(py::init<Mdp<storm::RationalFunction>>(), "parametric model"_a)
-        .def("instantiate", &storm::utility::ModelInstantiator<Mdp<storm::RationalFunction>, Mdp<storm::RationalFunction>>::instantiate,
-             "Instantiate model with given parameter values");
-
-    py::class_<storm::utility::ModelInstantiator<Ctmc<storm::RationalFunction>, Ctmc<storm::RationalFunction>>>(m, "PartialPCtmcInstantiator",
-                                                                                                                "Instantiate PCTMCs to CTMCs")
-        .def(py::init<Ctmc<storm::RationalFunction>>(), "parametric model"_a)
-        .def("instantiate", &storm::utility::ModelInstantiator<Ctmc<storm::RationalFunction>, Ctmc<storm::RationalFunction>>::instantiate,
-             "Instantiate model with given parameter values");
-
-    py::class_<storm::utility::ModelInstantiator<MarkovAutomaton<storm::RationalFunction>, MarkovAutomaton<storm::RationalFunction>>>(
-        m, "PartialPMaInstantiator", "Instantiate PMAs to MAs")
-        .def(py::init<MarkovAutomaton<storm::RationalFunction>>(), "parametric model"_a)
-        .def("instantiate", &storm::utility::ModelInstantiator<MarkovAutomaton<storm::RationalFunction>, MarkovAutomaton<storm::RationalFunction>>::instantiate,
-             "Instantiate model with given parameter values");
+    define_typed_instantiator<Dtmc<storm::RationalFunction>, Dtmc<ValueType>>(m, (prefix + "PDtmcInstantiator").c_str(), "Instantiate PDTMCs to DTMCs");
+    define_typed_instantiator<Mdp<storm::RationalFunction>, Mdp<ValueType>>(m, (prefix + "PMdpInstantiator").c_str(), "Instantiate PMDPs to MDPs");
+    define_typed_instantiator<Ctmc<storm::RationalFunction>, Ctmc<ValueType>>(m, (prefix + "PCtmcInstantiator").c_str(), "Instantiate PCTMCs to CTMCs");
+    define_typed_instantiator<MarkovAutomaton<storm::RationalFunction>, MarkovAutomaton<ValueType>>(m, (prefix + "PMaInstantiator").c_str(), "Instantiate PMAs to MAs");
 }
 
+// Trait: maps (ModelType, ResultType) to the specific checker class
+template<typename, typename> struct instantiation_checker;
+
+template<typename ResultType>
+struct instantiation_checker<Dtmc<storm::RationalFunction>, ResultType> {
+    using type = SparseDtmcInstantiationModelChecker<Dtmc<storm::RationalFunction>, ResultType>;
+};
+
+template<typename ResultType>
+struct instantiation_checker<Mdp<storm::RationalFunction>, ResultType> {
+    using type = SparseMdpInstantiationModelChecker<Mdp<storm::RationalFunction>, ResultType>;
+};
+
+template<typename ResultType>
+struct instantiation_checker<Ctmc<storm::RationalFunction>, ResultType> {
+    using type = SparseCtmcInstantiationModelChecker<Ctmc<storm::RationalFunction>, ResultType>;
+};
+
+// Helper: define typed base + derived instantiation checker pair
+template<typename ModelType, typename ResultType>
+void define_typed_checker(py::module& m, const char* baseName, const char* baseDesc, const char* derivedName, const char* derivedDesc) {
+    using CheckerType = typename instantiation_checker<ModelType, ResultType>::type;
+    using BaseChecker = SparseInstantiationModelChecker<ModelType, ResultType>;
+    auto base =
+        py::class_<BaseChecker, std::shared_ptr<BaseChecker>>(m, baseName, baseDesc);
+    base.def("specify_formula", &BaseChecker::specifyFormula, "check_task"_a);
+
+    py::class_<CheckerType, std::shared_ptr<CheckerType>>(m, derivedName, derivedDesc, base)
+        .def(py::init<ModelType>(), "parametric model"_a)
+        .def("check",
+             [](CheckerType& c, storm::Environment const& env,
+                storm::utility::parametric::Valuation<storm::RationalFunction> const& val) -> std::shared_ptr<CheckResult> { return c.check(env, val); },
+             "env"_a, "instantiation"_a)
+        .def("set_graph_preserving", &CheckerType::setInstantiationsAreGraphPreserving, "value"_a);
+}
+
+template<typename ValueType>
 void define_model_instantiation_checker(py::module& m) {
-    py::class_<SparseInstantiationModelChecker<Dtmc<storm::RationalFunction>, double>,
-               std::shared_ptr<SparseInstantiationModelChecker<Dtmc<storm::RationalFunction>, double>>>
-        bpdtmcinstchecker(m, "_PDtmcInstantiationCheckerBase", "Instantiate pDTMCs to DTMCs and immediately check (base)");
-    bpdtmcinstchecker.def("specify_formula", &SparseInstantiationModelChecker<Dtmc<storm::RationalFunction>, double>::specifyFormula, "check_task"_a);
+    std::string exactStr, exactDesc;
+    if constexpr (std::is_same_v<ValueType, double>) { exactStr = ""; exactDesc = ""; }
+    else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) { exactStr = "Exact"; exactDesc = "exact "; }
 
-    py::class_<SparseDtmcInstantiationModelChecker<Dtmc<storm::RationalFunction>, double>,
-               std::shared_ptr<SparseDtmcInstantiationModelChecker<Dtmc<storm::RationalFunction>, double>>>(
-        m, "PDtmcInstantiationChecker", "Instantiate pDTMCs to DTMCs and immediately check", bpdtmcinstchecker)
-        .def(py::init<Dtmc<storm::RationalFunction>>(), "parametric model"_a)
-        .def(
-            "check",
-            [](SparseDtmcInstantiationModelChecker<Dtmc<storm::RationalFunction>, double>& sdimc, storm::Environment const& env,
-               storm::utility::parametric::Valuation<storm::RationalFunction> const& val) -> std::shared_ptr<CheckResult> { return sdimc.check(env, val); },
-            "env"_a, "instantiation"_a)
-        .def("set_graph_preserving", &SparseDtmcInstantiationModelChecker<Dtmc<storm::RationalFunction>, double>::setInstantiationsAreGraphPreserving,
-             "value"_a);
+    // Dtmc
+    define_typed_checker<Dtmc<storm::RationalFunction>, ValueType>(
+        m, ("_PDtmc" + exactStr + "InstantiationCheckerBase").c_str(),
+        ("Instantiate pDTMCs to " + exactDesc + "DTMCs and immediately check (base)").c_str(),
+        ("PDtmc" + exactStr + "InstantiationChecker").c_str(),
+        ("Instantiate pDTMCs to " + exactDesc + "DTMCs and immediately check").c_str());
 
-    py::class_<SparseInstantiationModelChecker<Dtmc<storm::RationalFunction>, storm::RationalNumber>,
-               std::shared_ptr<SparseInstantiationModelChecker<Dtmc<storm::RationalFunction>, storm::RationalNumber>>>
-        bpdtmcexactinstchecker(m, "_PDtmcExactInstantiationCheckerBase", "Instantiate pDTMCs to exact DTMCs and immediately check (base)");
-    bpdtmcexactinstchecker.def("specify_formula", &SparseInstantiationModelChecker<Dtmc<storm::RationalFunction>, storm::RationalNumber>::specifyFormula,
-                               "check_task"_a);
+    // Mdp
+    define_typed_checker<Mdp<storm::RationalFunction>, ValueType>(
+        m, ("_PMdp" + exactStr + "InstantiationCheckerBase").c_str(),
+        ("Instantiate pMDPs to " + exactDesc + "MDPs and immediately check (base)").c_str(),
+        ("PMdp" + exactStr + "InstantiationChecker").c_str(),
+        ("Instantiate PMDP to " + exactDesc + "MDPs and immediately check").c_str());
 
-    py::class_<SparseDtmcInstantiationModelChecker<Dtmc<storm::RationalFunction>, storm::RationalNumber>,
-               std::shared_ptr<SparseDtmcInstantiationModelChecker<Dtmc<storm::RationalFunction>, storm::RationalNumber>>>(
-        m, "PDtmcExactInstantiationChecker", "Instantiate pDTMCs to exact DTMCs and immediately check", bpdtmcexactinstchecker)
-        .def(py::init<Dtmc<storm::RationalFunction>>(), "parametric model"_a)
-        .def(
-            "check",
-            [](SparseDtmcInstantiationModelChecker<Dtmc<storm::RationalFunction>, storm::RationalNumber>& sdimc, storm::Environment const& env,
-               storm::utility::parametric::Valuation<storm::RationalFunction> const& val) -> std::shared_ptr<CheckResult> { return sdimc.check(env, val); },
-            "env"_a, "instantiation"_a)
-        .def("set_graph_preserving",
-             &SparseDtmcInstantiationModelChecker<Dtmc<storm::RationalFunction>, storm::RationalNumber>::setInstantiationsAreGraphPreserving, "value"_a);
-
-    py::class_<SparseInstantiationModelChecker<Mdp<storm::RationalFunction>, double>,
-               std::shared_ptr<SparseInstantiationModelChecker<Mdp<storm::RationalFunction>, double>>>
-        bpmdpinstchecker(m, "_PMdpInstantiationCheckerBase", "Instantiate pMDPs to MDPs and immediately check (base)");
-    bpmdpinstchecker.def("specify_formula", &SparseInstantiationModelChecker<Mdp<storm::RationalFunction>, double>::specifyFormula, "check_task"_a);
-
-    py::class_<SparseMdpInstantiationModelChecker<Mdp<storm::RationalFunction>, double>,
-               std::shared_ptr<SparseMdpInstantiationModelChecker<Mdp<storm::RationalFunction>, double>>>(
-        m, "PMdpInstantiationChecker", "Instantiate PMDP to MDPs and immediately check", bpmdpinstchecker)
-        .def(py::init<Mdp<storm::RationalFunction>>(), "parametric model"_a)
-        .def(
-            "check",
-            [](SparseMdpInstantiationModelChecker<Mdp<storm::RationalFunction>, double>& sdimc, storm::Environment const& env,
-               storm::utility::parametric::Valuation<storm::RationalFunction> const& val) -> std::shared_ptr<CheckResult> { return sdimc.check(env, val); },
-            "env"_a, "instantiation"_a)
-        .def("set_graph_preserving", &SparseMdpInstantiationModelChecker<Mdp<storm::RationalFunction>, double>::setInstantiationsAreGraphPreserving, "value"_a);
-
-    py::class_<SparseInstantiationModelChecker<Mdp<storm::RationalFunction>, storm::RationalNumber>,
-               std::shared_ptr<SparseInstantiationModelChecker<Mdp<storm::RationalFunction>, storm::RationalNumber>>>
-        bpmdpexactinstchecker(m, "_PMdpExactInstantiationCheckerBase", "Instantiate pMDPs to exact MDPs and immediately check (base)");
-    bpmdpexactinstchecker.def("specify_formula", &SparseInstantiationModelChecker<Mdp<storm::RationalFunction>, storm::RationalNumber>::specifyFormula,
-                              "check_task"_a);
-
-    py::class_<SparseMdpInstantiationModelChecker<Mdp<storm::RationalFunction>, storm::RationalNumber>,
-               std::shared_ptr<SparseMdpInstantiationModelChecker<Mdp<storm::RationalFunction>, storm::RationalNumber>>>(
-        m, "PMdpExactInstantiationChecker", "Instantiate PMDP to exact MDPs and immediately check", bpmdpexactinstchecker)
-        .def(py::init<Mdp<storm::RationalFunction>>(), "parametric model"_a)
-        .def(
-            "check",
-            [](SparseMdpInstantiationModelChecker<Mdp<storm::RationalFunction>, storm::RationalNumber>& sdimc, storm::Environment const& env,
-               storm::utility::parametric::Valuation<storm::RationalFunction> const& val) -> std::shared_ptr<CheckResult> { return sdimc.check(env, val); },
-            "env"_a, "instantiation"_a)
-        .def("set_graph_preserving",
-             &SparseMdpInstantiationModelChecker<Mdp<storm::RationalFunction>, storm::RationalNumber>::setInstantiationsAreGraphPreserving, "value"_a);
-
-    py::class_<SparseInstantiationModelChecker<Ctmc<storm::RationalFunction>, double>,
-               std::shared_ptr<SparseInstantiationModelChecker<Ctmc<storm::RationalFunction>, double>>>
-        bpctmcinstchecker(m, "_PCtmcInstantiationCheckerBase", "Instantiate pCTMCs to CTMCs and immediately check (base)");
-    bpctmcinstchecker.def("specify_formula", &SparseInstantiationModelChecker<Ctmc<storm::RationalFunction>, double>::specifyFormula, "check_task"_a);
-
-    py::class_<SparseCtmcInstantiationModelChecker<Ctmc<storm::RationalFunction>, double>,
-               std::shared_ptr<SparseCtmcInstantiationModelChecker<Ctmc<storm::RationalFunction>, double>>>(
-        m, "PCtmcInstantiationChecker", "Instantiate pCTMCs to CTMCs and immediately check", bpctmcinstchecker)
-        .def(py::init<Ctmc<storm::RationalFunction>>(), "parametric model"_a)
-        .def(
-            "check",
-            [](SparseCtmcInstantiationModelChecker<Ctmc<storm::RationalFunction>, double>& scimc, storm::Environment const& env,
-               storm::utility::parametric::Valuation<storm::RationalFunction> const& val) -> std::shared_ptr<CheckResult> { return scimc.check(env, val); },
-            "env"_a, "instantiation"_a)
-        .def("set_graph_preserving", &SparseCtmcInstantiationModelChecker<Ctmc<storm::RationalFunction>, double>::setInstantiationsAreGraphPreserving,
-             "value"_a);
-
-    py::class_<SparseInstantiationModelChecker<Ctmc<storm::RationalFunction>, storm::RationalNumber>,
-               std::shared_ptr<SparseInstantiationModelChecker<Ctmc<storm::RationalFunction>, storm::RationalNumber>>>
-        bpctmcexactinstchecker(m, "_PCtmcExactInstantiationCheckerBase", "Instantiate pCTMCs to exact CTMCs and immediately check (base)");
-    bpctmcexactinstchecker.def("specify_formula", &SparseInstantiationModelChecker<Ctmc<storm::RationalFunction>, storm::RationalNumber>::specifyFormula,
-                               "check_task"_a);
-
-    py::class_<SparseCtmcInstantiationModelChecker<Ctmc<storm::RationalFunction>, storm::RationalNumber>,
-               std::shared_ptr<SparseCtmcInstantiationModelChecker<Ctmc<storm::RationalFunction>, storm::RationalNumber>>>(
-        m, "PCtmcExactInstantiationChecker", "Instantiate pCTMCs to exact CTMCs and immediately check", bpctmcexactinstchecker)
-        .def(py::init<Ctmc<storm::RationalFunction>>(), "parametric model"_a)
-        .def(
-            "check",
-            [](SparseCtmcInstantiationModelChecker<Ctmc<storm::RationalFunction>, storm::RationalNumber>& scimc, storm::Environment const& env,
-               storm::utility::parametric::Valuation<storm::RationalFunction> const& val) -> std::shared_ptr<CheckResult> { return scimc.check(env, val); },
-            "env"_a, "instantiation"_a)
-        .def("set_graph_preserving",
-             &SparseCtmcInstantiationModelChecker<Ctmc<storm::RationalFunction>, storm::RationalNumber>::setInstantiationsAreGraphPreserving, "value"_a);
+    // Ctmc
+    define_typed_checker<Ctmc<storm::RationalFunction>, ValueType>(
+        m, ("_PCtmc" + exactStr + "InstantiationCheckerBase").c_str(),
+        ("Instantiate pCTMCs to " + exactDesc + "CTMCs and immediately check (base)").c_str(),
+        ("PCtmc" + exactStr + "InstantiationChecker").c_str(),
+        ("Instantiate pCTMCs to " + exactDesc + "CTMCs and immediately check").c_str());
 }
+
+template void define_model_instantiator<double>(py::module&);
+template void define_model_instantiator<storm::RationalFunction>(py::module&);
+template void define_model_instantiation_checker<double>(py::module&);
+template void define_model_instantiation_checker<storm::RationalNumber>(py::module&);

--- a/src/pars/model_instantiator.h
+++ b/src/pars/model_instantiator.h
@@ -2,5 +2,8 @@
 
 #include "src/pars/common.h"
 
+template<typename ValueType>
 void define_model_instantiator(py::module& m);
+
+template<typename ValueType>
 void define_model_instantiation_checker(py::module& m);

--- a/src/storage/dd.cpp
+++ b/src/storage/dd.cpp
@@ -9,7 +9,7 @@
 #include "src/helpers.h"
 
 template<storm::dd::DdType DdType>
-void define_dd(py::module& m, std::string const& libstring) {
+py::class_<storm::dd::Dd<DdType>> define_dd(py::module& m, std::string const& libstring) {
     py::class_<storm::dd::DdMetaVariable<DdType>> ddMetaVariable(m, (std::string("DdMetaVariable_") + libstring).c_str());
     ddMetaVariable.def("compute_indices", &storm::dd::DdMetaVariable<DdType>::getIndices, py::arg("sorted") = true);
     ddMetaVariable.def_property_readonly("name", &storm::dd::DdMetaVariable<DdType>::getName);
@@ -30,13 +30,19 @@ void define_dd(py::module& m, std::string const& libstring) {
     py::class_<storm::dd::Bdd<DdType>> bdd(m, (std::string("Bdd_") + libstring).c_str(), "Bdd", dd);
     bdd.def("to_expression", &storm::dd::Bdd<DdType>::toExpression, py::arg("expression_manager"));
 
-    py::class_<storm::dd::Add<DdType, double>> add(m, (std::string("Add_") + libstring + "_Double").c_str(), "Add", dd);
+    return dd;
+}
+
+template<storm::dd::DdType DdType, typename ValueType>
+void define_dd_typed(py::module& m, std::string const& libstring, std::string const& valueSuffix,
+                     py::class_<storm::dd::Dd<DdType>> const& dd) {
+    py::class_<storm::dd::Add<DdType, ValueType>> add(m, (std::string("Add_") + libstring + valueSuffix).c_str(), "Add", dd);
     add.def(
-        "__iter__", [](const storm::dd::Add<DdType, double>& s) { return py::make_iterator(s.begin(), s.end()); },
+        "__iter__", [](const storm::dd::Add<DdType, ValueType>& s) { return py::make_iterator(s.begin(), s.end()); },
         py::keep_alive<0, 1>() /* Essential: keep object alive while iterator exists */);
 
-    py::class_<storm::dd::AddIterator<DdType, double>> addIterator(m, (std::string("AddIterator_") + libstring + "_Double").c_str(), "AddIterator");
-    addIterator.def("get", [](const storm::dd::AddIterator<DdType, double>& it) { return *it; });
+    py::class_<storm::dd::AddIterator<DdType, ValueType>> addIterator(m, (std::string("AddIterator_") + libstring + valueSuffix).c_str(), "AddIterator");
+    addIterator.def("get", [](const storm::dd::AddIterator<DdType, ValueType>& it) { return *it; });
 }
 
 void define_dd_nt(py::module& m) {
@@ -47,4 +53,6 @@ void define_dd_nt(py::module& m) {
         .finalize();
 }
 
-template void define_dd<storm::dd::DdType::Sylvan>(py::module& m, std::string const& libstring);
+template py::class_<storm::dd::Dd<storm::dd::DdType::Sylvan>> define_dd<storm::dd::DdType::Sylvan>(py::module& m, std::string const& libstring);
+template void define_dd_typed<storm::dd::DdType::Sylvan, double>(py::module&, std::string const&, std::string const&,
+                                                                   py::class_<storm::dd::Dd<storm::dd::DdType::Sylvan>> const&);

--- a/src/storage/dd.cpp
+++ b/src/storage/dd.cpp
@@ -34,8 +34,7 @@ py::class_<storm::dd::Dd<DdType>> define_dd(py::module& m, std::string const& li
 }
 
 template<storm::dd::DdType DdType, typename ValueType>
-void define_dd_typed(py::module& m, std::string const& libstring, std::string const& valueSuffix,
-                     py::class_<storm::dd::Dd<DdType>> const& dd) {
+void define_dd_typed(py::module& m, std::string const& libstring, std::string const& valueSuffix, py::class_<storm::dd::Dd<DdType>> const& dd) {
     py::class_<storm::dd::Add<DdType, ValueType>> add(m, (std::string("Add_") + libstring + valueSuffix).c_str(), "Add", dd);
     add.def(
         "__iter__", [](const storm::dd::Add<DdType, ValueType>& s) { return py::make_iterator(s.begin(), s.end()); },
@@ -55,4 +54,4 @@ void define_dd_nt(py::module& m) {
 
 template py::class_<storm::dd::Dd<storm::dd::DdType::Sylvan>> define_dd<storm::dd::DdType::Sylvan>(py::module& m, std::string const& libstring);
 template void define_dd_typed<storm::dd::DdType::Sylvan, double>(py::module&, std::string const&, std::string const&,
-                                                                   py::class_<storm::dd::Dd<storm::dd::DdType::Sylvan>> const&);
+                                                                 py::class_<storm::dd::Dd<storm::dd::DdType::Sylvan>> const&);

--- a/src/storage/dd.h
+++ b/src/storage/dd.h
@@ -1,9 +1,14 @@
 #pragma once
 
+#include <storm/storage/dd/Dd.h>
 #include <storm/storage/dd/DdType.h>
 
 #include "src/common.h"
 
 template<storm::dd::DdType DdType>
-void define_dd(py::module& m, std::string const& libname);
+py::class_<storm::dd::Dd<DdType>> define_dd(py::module& m, std::string const& libname);
+template<storm::dd::DdType DdType, typename ValueType>
+void define_dd_typed(py::module& m, std::string const& libstring, std::string const& valueSuffix,
+                     py::class_<storm::dd::Dd<DdType>> const& dd);
+
 void define_dd_nt(py::module& m);

--- a/src/storage/dd.h
+++ b/src/storage/dd.h
@@ -8,7 +8,6 @@
 template<storm::dd::DdType DdType>
 py::class_<storm::dd::Dd<DdType>> define_dd(py::module& m, std::string const& libname);
 template<storm::dd::DdType DdType, typename ValueType>
-void define_dd_typed(py::module& m, std::string const& libstring, std::string const& valueSuffix,
-                     py::class_<storm::dd::Dd<DdType>> const& dd);
+void define_dd_typed(py::module& m, std::string const& libstring, std::string const& valueSuffix, py::class_<storm::dd::Dd<DdType>> const& dd);
 
 void define_dd_nt(py::module& m);

--- a/src/storage/memorystructure.cpp
+++ b/src/storage/memorystructure.cpp
@@ -7,29 +7,27 @@
 #include <storm/storage/memorystructure/SparseModelMemoryProduct.h>
 #include <storm/storage/memorystructure/SparseModelMemoryProductReverseData.h>
 
+template<typename ValueType>
+void define_memorystructure_product_each(py::class_<storm::storage::MemoryStructure, std::shared_ptr<storm::storage::MemoryStructure>>& memoryStructure,
+                                         py::class_<storm::storage::SparseModelMemoryProductReverseData>& reverseData, std::string const& vtSuffix) {
+    memoryStructure.def(("_product_model" + vtSuffix).c_str(),
+                        [](storm::storage::MemoryStructure& ms, storm::models::sparse::Model<ValueType> const& sparseModel) { return ms.product(sparseModel); });
+    reverseData.def(("_reverse_scheduler" + vtSuffix).c_str(),
+                    &storm::storage::SparseModelMemoryProductReverseData::createMemorySchedulerFromProductScheduler<ValueType>,
+                    py::arg("product_scheduler"));
+}
+
 void define_memorystructure_untyped(py::module& m) {
     typedef storm::storage::MemoryStructure MemoryStructure;
     py::class_<MemoryStructure, std::shared_ptr<MemoryStructure>> memoryStructure(m, "MemoryStructure");
     memoryStructure.def("product", [](MemoryStructure& ms, MemoryStructure const& memModel) { return ms.product(memModel); });
-    memoryStructure.def("_product_model_double",
-                        [](MemoryStructure& ms, storm::models::sparse::Model<double> const& sparseModel) { return ms.product(sparseModel); });
-    memoryStructure.def("_product_model_exact",
-                        [](MemoryStructure& ms, storm::models::sparse::Model<storm::RationalNumber> const& sparseModel) { return ms.product(sparseModel); });
-    memoryStructure.def("_product_model_parametric",
-                        [](MemoryStructure& ms, storm::models::sparse::Model<storm::RationalFunction> const& sparseModel) { return ms.product(sparseModel); });
     memoryStructure.def_property_readonly("nr_states", &MemoryStructure::getNumberOfStates);
     memoryStructure.def_property_readonly("state_labeling", &MemoryStructure::getStateLabeling);
 
     py::class_<storm::storage::SparseModelMemoryProductReverseData> memoryProductReverseData(m, "SparseModelMemoryProductReverseData");
-    memoryProductReverseData.def("_reverse_scheduler_double",
-                                 &storm::storage::SparseModelMemoryProductReverseData::createMemorySchedulerFromProductScheduler<double>,
-                                 py::arg("product_scheduler"));
-    memoryProductReverseData.def("_reverse_scheduler_exact",
-                                 &storm::storage::SparseModelMemoryProductReverseData::createMemorySchedulerFromProductScheduler<storm::RationalNumber>,
-                                 py::arg("product_scheduler"));
-    memoryProductReverseData.def("_reverse_scheduler_parametric",
-                                 &storm::storage::SparseModelMemoryProductReverseData::createMemorySchedulerFromProductScheduler<storm::RationalFunction>,
-                                 py::arg("product_scheduler"));
+    define_memorystructure_product_each<double>(memoryStructure, memoryProductReverseData, "_double");
+    define_memorystructure_product_each<storm::RationalNumber>(memoryStructure, memoryProductReverseData, "_exact");
+    define_memorystructure_product_each<storm::RationalFunction>(memoryStructure, memoryProductReverseData, "_parametric");
 }
 
 template<typename VT>

--- a/src/storage/memorystructure.cpp
+++ b/src/storage/memorystructure.cpp
@@ -10,11 +10,11 @@
 template<typename ValueType>
 void define_memorystructure_product_each(py::class_<storm::storage::MemoryStructure, std::shared_ptr<storm::storage::MemoryStructure>>& memoryStructure,
                                          py::class_<storm::storage::SparseModelMemoryProductReverseData>& reverseData, std::string const& vtSuffix) {
-    memoryStructure.def(("_product_model" + vtSuffix).c_str(),
-                        [](storm::storage::MemoryStructure& ms, storm::models::sparse::Model<ValueType> const& sparseModel) { return ms.product(sparseModel); });
+    memoryStructure.def(
+        ("_product_model" + vtSuffix).c_str(),
+        [](storm::storage::MemoryStructure& ms, storm::models::sparse::Model<ValueType> const& sparseModel) { return ms.product(sparseModel); });
     reverseData.def(("_reverse_scheduler" + vtSuffix).c_str(),
-                    &storm::storage::SparseModelMemoryProductReverseData::createMemorySchedulerFromProductScheduler<ValueType>,
-                    py::arg("product_scheduler"));
+                    &storm::storage::SparseModelMemoryProductReverseData::createMemorySchedulerFromProductScheduler<ValueType>, py::arg("product_scheduler"));
 }
 
 void define_memorystructure_untyped(py::module& m) {

--- a/src/storage/model.cpp
+++ b/src/storage/model.cpp
@@ -91,6 +91,41 @@ storm::models::sparse::StateLabeling& getLabeling(SparseModel<ValueType>& model)
     return model.getStateLabeling();
 }
 
+template<typename ValueType>
+void define_model_as_sparse(py::class_<ModelBase, std::shared_ptr<ModelBase>>& modelBase) {
+    std::string prefix;
+    if constexpr (std::is_same_v<ValueType, double>) prefix = "";
+    else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) prefix = "exact_";
+    else if constexpr (std::is_same_v<ValueType, storm::Interval>) prefix = "i";
+    else if constexpr (std::is_same_v<ValueType, storm::RationalInterval>) prefix = "exact_i";
+    else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) prefix = "p";
+
+    modelBase.def(("_as_sparse_" + prefix + "dtmc").c_str(), [](ModelBase& m) { return m.template as<SparseDtmc<ValueType>>(); }, "Get model as sparse DTMC");
+    modelBase.def(("_as_sparse_" + prefix + "mdp").c_str(), [](ModelBase& m) { return m.template as<SparseMdp<ValueType>>(); }, "Get model as sparse MDP");
+    modelBase.def(("_as_sparse_" + prefix + "pomdp").c_str(), [](ModelBase& m) { return m.template as<SparsePomdp<ValueType>>(); }, "Get model as sparse POMDP");
+    modelBase.def(("_as_sparse_" + prefix + "ctmc").c_str(), [](ModelBase& m) { return m.template as<SparseCtmc<ValueType>>(); }, "Get model as sparse CTMC");
+    modelBase.def(("_as_sparse_" + prefix + "ma").c_str(), [](ModelBase& m) { return m.template as<SparseMarkovAutomaton<ValueType>>(); }, "Get model as sparse MA");
+    modelBase.def(("_as_sparse_" + prefix + "smg").c_str(), [](ModelBase& m) { return m.template as<SparseSmg<ValueType>>(); }, "Get model as sparse SMG");
+}
+
+template<typename ValueType>
+void define_model_as_symbolic(py::class_<ModelBase, std::shared_ptr<ModelBase>>& modelBase) {
+    std::string prefix;
+    if constexpr (std::is_same_v<ValueType, double>) prefix = "";
+    else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) prefix = "exact_";
+    else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) prefix = "p";
+    else return;
+
+    modelBase.def(("_as_symbolic_" + prefix + "dtmc").c_str(),
+                  [](ModelBase& m) { return m.template as<SymbolicDtmc<storm::dd::DdType::Sylvan, ValueType>>(); }, "Get model as symbolic DTMC");
+    modelBase.def(("_as_symbolic_" + prefix + "mdp").c_str(),
+                  [](ModelBase& m) { return m.template as<SymbolicMdp<storm::dd::DdType::Sylvan, ValueType>>(); }, "Get model as symbolic MDP");
+    modelBase.def(("_as_symbolic_" + prefix + "ctmc").c_str(),
+                  [](ModelBase& m) { return m.template as<SymbolicCtmc<storm::dd::DdType::Sylvan, ValueType>>(); }, "Get model as symbolic CTMC");
+    modelBase.def(("_as_symbolic_" + prefix + "ma").c_str(),
+                  [](ModelBase& m) { return m.template as<SymbolicMarkovAutomaton<storm::dd::DdType::Sylvan, ValueType>>(); }, "Get model as symbolic MA");
+}
+
 // Bindings for general models
 void define_model(py::module& m) {
     // ModelType
@@ -116,117 +151,15 @@ void define_model(py::module& m) {
         .def_property_readonly("is_sparse_model", &ModelBase::isSparseModel, "Flag whether the model is stored as a sparse model")
         .def_property_readonly("is_symbolic_model", &ModelBase::isSymbolicModel, "Flag whether the model is stored using decision diagrams")
         .def_property_readonly("is_discrete_time_model", &ModelBase::isDiscreteTimeModel, "Flag whether the model is a discrete time model")
-        .def_property_readonly("is_nondeterministic_model", &ModelBase::isNondeterministicModel, "Flag whether the model contains nondeterminism")
-        .def(
-            "_as_sparse_dtmc", [](ModelBase& modelbase) { return modelbase.as<SparseDtmc<double>>(); }, "Get model as sparse DTMC")
-        .def(
-            "_as_sparse_exact_dtmc", [](ModelBase& modelbase) { return modelbase.as<SparseDtmc<storm::RationalNumber>>(); }, "Get model as sparse exact DTMC")
-        .def(
-            "_as_sparse_idtmc", [](ModelBase& modelbase) { return modelbase.as<SparseDtmc<storm::Interval>>(); }, "Get model as sparse interval DTMC")
-        .def(
-            "_as_sparse_pdtmc", [](ModelBase& modelbase) { return modelbase.as<SparseDtmc<storm::RationalFunction>>(); }, "Get model as sparse parametric DTMC")
-        .def(
-            "_as_sparse_idtmc", [](ModelBase& modelbase) { return modelbase.as<SparseDtmc<storm::Interval>>(); }, "Get model as sparse interval DTMC")
-        .def(
-            "_as_sparse_exact_idtmc", [](ModelBase& modelbase) { return modelbase.as<SparseDtmc<storm::RationalInterval>>(); },
-            "Get model as sparse exact interval DTMC")
-        .def(
-            "_as_sparse_mdp", [](ModelBase& modelbase) { return modelbase.as<SparseMdp<double>>(); }, "Get model as sparse MDP")
-        .def(
-            "_as_sparse_exact_mdp", [](ModelBase& modelbase) { return modelbase.as<SparseMdp<storm::RationalNumber>>(); }, "Get model as sparse exact MDP")
-        .def(
-            "_as_sparse_imdp", [](ModelBase& modelbase) { return modelbase.as<SparseMdp<storm::Interval>>(); }, "Get model as sparse interval MDP")
-        .def(
-            "_as_sparse_exact_imdp", [](ModelBase& modelbase) { return modelbase.as<SparseMdp<storm::RationalInterval>>(); },
-            "Get model as sparse exact interval MDP")
-        .def(
-            "_as_sparse_pmdp", [](ModelBase& modelbase) { return modelbase.as<SparseMdp<storm::RationalFunction>>(); }, "Get model as sparse parametric MDP")
-        .def(
-            "_as_sparse_pomdp", [](ModelBase& modelbase) { return modelbase.as<SparsePomdp<double>>(); }, "Get model as sparse POMDP")
-        .def(
-            "_as_sparse_ipomdp", [](ModelBase& modelbase) { return modelbase.as<SparsePomdp<storm::Interval>>(); }, "Get model as sparse interval POMDP")
-        .def(
-            "_as_sparse_exact_ipomdp", [](ModelBase& modelbase) { return modelbase.as<SparsePomdp<storm::RationalInterval>>(); },
-            "Get model as sparse interval exact POMDP")
-        .def(
-            "_as_sparse_exact_pomdp", [](ModelBase& modelbase) { return modelbase.as<SparsePomdp<storm::RationalNumber>>(); },
-            "Get model as sparse exact POMDP")
-        .def(
-            "_as_sparse_ppomdp", [](ModelBase& modelbase) { return modelbase.as<SparsePomdp<storm::RationalFunction>>(); },
-            "Get model as sparse parametric POMDP")
-        .def(
-            "_as_sparse_ctmc", [](ModelBase& modelbase) { return modelbase.as<SparseCtmc<double>>(); }, "Get model as sparse CTMC")
-        .def(
-            "_as_sparse_exact_ctmc", [](ModelBase& modelbase) { return modelbase.as<SparseCtmc<storm::RationalNumber>>(); }, "Get model as sparse exact CTMC")
-        .def(
-            "_as_sparse_ictmc", [](ModelBase& modelbase) { return modelbase.as<SparseCtmc<storm::Interval>>(); }, "Get model as sparse interval CTMC")
-        .def(
-            "_as_sparse_exact_ictmc", [](ModelBase& modelbase) { return modelbase.as<SparseCtmc<storm::RationalInterval>>(); },
-            "Get model as sparse exact interval CTMC")
-        .def(
-            "_as_sparse_pctmc", [](ModelBase& modelbase) { return modelbase.as<SparseCtmc<storm::RationalFunction>>(); }, "Get model as sparse parametric CTMC")
-        .def(
-            "_as_sparse_ma", [](ModelBase& modelbase) { return modelbase.as<SparseMarkovAutomaton<double>>(); }, "Get model as sparse MA")
-        .def(
-            "_as_sparse_exact_ma", [](ModelBase& modelbase) { return modelbase.as<SparseMarkovAutomaton<storm::RationalNumber>>(); },
-            "Get model as sparse exact MA")
-        .def(
-            "_as_sparse_ima", [](ModelBase& modelbase) { return modelbase.as<SparseMarkovAutomaton<storm::Interval>>(); }, "Get model as sparse interval MA")
-        .def(
-            "_as_sparse_exact_ima", [](ModelBase& modelbase) { return modelbase.as<SparseMarkovAutomaton<storm::RationalInterval>>(); },
-            "Get model as sparse exact interval MA")
-        .def(
-            "_as_sparse_pma", [](ModelBase& modelbase) { return modelbase.as<SparseMarkovAutomaton<storm::RationalFunction>>(); },
-            "Get model as sparse parametric MA")
-        .def(
-            "_as_sparse_smg", [](ModelBase& modelbase) { return modelbase.as<SparseSmg<double>>(); }, "Get model as sparse SMG")
-        .def(
-            "_as_sparse_exact_smg", [](ModelBase& modelbase) { return modelbase.as<SparseSmg<storm::RationalNumber>>(); }, "Get model as sparse exact SMG")
-        .def(
-            "_as_sparse_ismg", [](ModelBase& modelbase) { return modelbase.as<SparseSmg<storm::Interval>>(); }, "Get model as sparse interval SMG")
-        .def(
-            "_as_sparse_exact_ismg", [](ModelBase& modelbase) { return modelbase.as<SparseSmg<storm::RationalInterval>>(); },
-            "Get model as sparse exact interval SMG")
-        .def(
-            "_as_sparse_psmg", [](ModelBase& modelbase) { return modelbase.as<SparseSmg<storm::RationalFunction>>(); }, "Get model as sparse parametric SMG")
-        .def(
-            "_as_symbolic_dtmc", [](ModelBase& modelbase) { return modelbase.as<SymbolicDtmc<storm::dd::DdType::Sylvan, double>>(); },
-            "Get model as symbolic DTMC")
-        .def(
-            "_as_symbolic_exact_dtmc", [](ModelBase& modelbase) { return modelbase.as<SymbolicDtmc<storm::dd::DdType::Sylvan, storm::RationalNumber>>(); },
-            "Get model as symbolic exact DTMC")
-        .def(
-            "_as_symbolic_pdtmc", [](ModelBase& modelbase) { return modelbase.as<SymbolicDtmc<storm::dd::DdType::Sylvan, storm::RationalFunction>>(); },
-            "Get model as symbolic parametric DTMC")
-        .def(
-            "_as_symbolic_mdp", [](ModelBase& modelbase) { return modelbase.as<SymbolicMdp<storm::dd::DdType::Sylvan, double>>(); },
-            "Get model as symbolic MDP")
-        .def(
-            "_as_symbolic_exact_mdp", [](ModelBase& modelbase) { return modelbase.as<SymbolicMdp<storm::dd::DdType::Sylvan, storm::RationalNumber>>(); },
-            "Get model as symbolic exact MDP")
-        .def(
-            "_as_symbolic_pmdp", [](ModelBase& modelbase) { return modelbase.as<SymbolicMdp<storm::dd::DdType::Sylvan, storm::RationalFunction>>(); },
-            "Get model as symbolic parametric MDP")
-        .def(
-            "_as_symbolic_ctmc", [](ModelBase& modelbase) { return modelbase.as<SymbolicCtmc<storm::dd::DdType::Sylvan, double>>(); },
-            "Get model as symbolic CTMC")
-        .def(
-            "_as_symbolic_exact_ctmc", [](ModelBase& modelbase) { return modelbase.as<SymbolicCtmc<storm::dd::DdType::Sylvan, storm::RationalNumber>>(); },
-            "Get model as symbolic exact CTMC")
-        .def(
-            "_as_symbolic_pctmc", [](ModelBase& modelbase) { return modelbase.as<SymbolicCtmc<storm::dd::DdType::Sylvan, storm::RationalFunction>>(); },
-            "Get model as symbolic parametric CTMC")
-        .def(
-            "_as_symbolic_ma", [](ModelBase& modelbase) { return modelbase.as<SymbolicMarkovAutomaton<storm::dd::DdType::Sylvan, double>>(); },
-            "Get model as symbolic MA")
-        .def(
-            "_as_symbolic_exact_ma",
-            [](ModelBase& modelbase) { return modelbase.as<SymbolicMarkovAutomaton<storm::dd::DdType::Sylvan, storm::RationalNumber>>(); },
-            "Get model as symbolic exact MA")
-        .def(
-            "_as_symbolic_pma",
-            [](ModelBase& modelbase) { return modelbase.as<SymbolicMarkovAutomaton<storm::dd::DdType::Sylvan, storm::RationalFunction>>(); },
-            "Get model as symbolic parametric MA");
+        .def_property_readonly("is_nondeterministic_model", &ModelBase::isNondeterministicModel, "Flag whether the model contains nondeterminism");
+    define_model_as_sparse<double>(modelBase);
+    define_model_as_sparse<storm::RationalNumber>(modelBase);
+    define_model_as_sparse<storm::Interval>(modelBase);
+    define_model_as_sparse<storm::RationalInterval>(modelBase);
+    define_model_as_sparse<storm::RationalFunction>(modelBase);
+    define_model_as_symbolic<double>(modelBase);
+    define_model_as_symbolic<storm::RationalNumber>(modelBase);
+    define_model_as_symbolic<storm::RationalFunction>(modelBase);
 }
 
 // Bindings for sparse models

--- a/src/storage/model.cpp
+++ b/src/storage/model.cpp
@@ -94,34 +94,45 @@ storm::models::sparse::StateLabeling& getLabeling(SparseModel<ValueType>& model)
 template<typename ValueType>
 void define_model_as_sparse(py::class_<ModelBase, std::shared_ptr<ModelBase>>& modelBase) {
     std::string prefix;
-    if constexpr (std::is_same_v<ValueType, double>) prefix = "";
-    else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) prefix = "exact_";
-    else if constexpr (std::is_same_v<ValueType, storm::Interval>) prefix = "i";
-    else if constexpr (std::is_same_v<ValueType, storm::RationalInterval>) prefix = "exact_i";
-    else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) prefix = "p";
+    if constexpr (std::is_same_v<ValueType, double>)
+        prefix = "";
+    else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>)
+        prefix = "exact_";
+    else if constexpr (std::is_same_v<ValueType, storm::Interval>)
+        prefix = "i";
+    else if constexpr (std::is_same_v<ValueType, storm::RationalInterval>)
+        prefix = "exact_i";
+    else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>)
+        prefix = "p";
 
     modelBase.def(("_as_sparse_" + prefix + "dtmc").c_str(), [](ModelBase& m) { return m.template as<SparseDtmc<ValueType>>(); }, "Get model as sparse DTMC");
     modelBase.def(("_as_sparse_" + prefix + "mdp").c_str(), [](ModelBase& m) { return m.template as<SparseMdp<ValueType>>(); }, "Get model as sparse MDP");
-    modelBase.def(("_as_sparse_" + prefix + "pomdp").c_str(), [](ModelBase& m) { return m.template as<SparsePomdp<ValueType>>(); }, "Get model as sparse POMDP");
+    modelBase.def(("_as_sparse_" + prefix + "pomdp").c_str(), [](ModelBase& m) { return m.template as<SparsePomdp<ValueType>>(); },
+                  "Get model as sparse POMDP");
     modelBase.def(("_as_sparse_" + prefix + "ctmc").c_str(), [](ModelBase& m) { return m.template as<SparseCtmc<ValueType>>(); }, "Get model as sparse CTMC");
-    modelBase.def(("_as_sparse_" + prefix + "ma").c_str(), [](ModelBase& m) { return m.template as<SparseMarkovAutomaton<ValueType>>(); }, "Get model as sparse MA");
+    modelBase.def(("_as_sparse_" + prefix + "ma").c_str(), [](ModelBase& m) { return m.template as<SparseMarkovAutomaton<ValueType>>(); },
+                  "Get model as sparse MA");
     modelBase.def(("_as_sparse_" + prefix + "smg").c_str(), [](ModelBase& m) { return m.template as<SparseSmg<ValueType>>(); }, "Get model as sparse SMG");
 }
 
 template<typename ValueType>
 void define_model_as_symbolic(py::class_<ModelBase, std::shared_ptr<ModelBase>>& modelBase) {
     std::string prefix;
-    if constexpr (std::is_same_v<ValueType, double>) prefix = "";
-    else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) prefix = "exact_";
-    else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) prefix = "p";
-    else return;
+    if constexpr (std::is_same_v<ValueType, double>)
+        prefix = "";
+    else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>)
+        prefix = "exact_";
+    else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>)
+        prefix = "p";
+    else
+        return;
 
-    modelBase.def(("_as_symbolic_" + prefix + "dtmc").c_str(),
-                  [](ModelBase& m) { return m.template as<SymbolicDtmc<storm::dd::DdType::Sylvan, ValueType>>(); }, "Get model as symbolic DTMC");
-    modelBase.def(("_as_symbolic_" + prefix + "mdp").c_str(),
-                  [](ModelBase& m) { return m.template as<SymbolicMdp<storm::dd::DdType::Sylvan, ValueType>>(); }, "Get model as symbolic MDP");
-    modelBase.def(("_as_symbolic_" + prefix + "ctmc").c_str(),
-                  [](ModelBase& m) { return m.template as<SymbolicCtmc<storm::dd::DdType::Sylvan, ValueType>>(); }, "Get model as symbolic CTMC");
+    modelBase.def(("_as_symbolic_" + prefix + "dtmc").c_str(), [](ModelBase& m) { return m.template as<SymbolicDtmc<storm::dd::DdType::Sylvan, ValueType>>(); },
+                  "Get model as symbolic DTMC");
+    modelBase.def(("_as_symbolic_" + prefix + "mdp").c_str(), [](ModelBase& m) { return m.template as<SymbolicMdp<storm::dd::DdType::Sylvan, ValueType>>(); },
+                  "Get model as symbolic MDP");
+    modelBase.def(("_as_symbolic_" + prefix + "ctmc").c_str(), [](ModelBase& m) { return m.template as<SymbolicCtmc<storm::dd::DdType::Sylvan, ValueType>>(); },
+                  "Get model as symbolic CTMC");
     modelBase.def(("_as_symbolic_" + prefix + "ma").c_str(),
                   [](ModelBase& m) { return m.template as<SymbolicMarkovAutomaton<storm::dd::DdType::Sylvan, ValueType>>(); }, "Get model as symbolic MA");
 }


### PR DESCRIPTION
Added more templates when defining bindings for different ValueTypes. At the moment, this is fully backwards-compatible and inconsistencies remain regarding the naming of functions. This will be addressed in a separate PR.

Contributions from opencode [bot@opencode.ai](mailto:bot@opencode.ai) (model: opencode/big-pickle).