### PR TITLE
Revised CI for wheel creation

### DIFF
--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -125,11 +125,11 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deploy_target }}
           # Build development version only on latest Python versions
           CIBW_BUILD: "cp313-* cp314-*"
-          CIBW_CONFIG_SETTINGS: cmake.build-type=${{ inputs.build_type }}
           CIBW_ENVIRONMENT: >-
             STORM_VERSION=${{ inputs.storm_version }}
             NR_JOBS=${{ env.NR_JOBS }}
             CMAKE_BUILD_PARALLEL_LEVEL=${{ env.NR_JOBS }}
+            SKBUILD_CMAKE_BUILD_TYPE=${{ inputs.build_type }}
             CMAKE_BUILD_TYPE=${{ inputs.build_type }}
       - name: Build wheels (stable)
         if: ${{ inputs.full_build }}
@@ -138,11 +138,11 @@ jobs:
           CIBW_PLATFORM: ${{ matrix.platform }}
           CIBW_ARCHS: ${{ matrix.archs }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deploy_target }}
-          CIBW_CONFIG_SETTINGS: cmake.build-type=${{ inputs.build_type }}
           CIBW_ENVIRONMENT: >-
             STORM_VERSION=${{ inputs.storm_version }}
             NR_JOBS=${{ env.NR_JOBS }}
             CMAKE_BUILD_PARALLEL_LEVEL=${{ env.NR_JOBS }}
+            SKBUILD_CMAKE_BUILD_TYPE=${{ inputs.build_type }}
             CMAKE_BUILD_TYPE=${{ inputs.build_type }}
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -1,5 +1,8 @@
 name: Build and test wheels
 
+env:
+  NR_JOBS: "4"
+
 on:
   # needed to reuse the workflow from another one
   workflow_call:
@@ -125,7 +128,8 @@ jobs:
           CIBW_CONFIG_SETTINGS: cmake.build-type=${{ inputs.build_type }}
           CIBW_ENVIRONMENT: >-
             STORM_VERSION=${{ inputs.storm_version }}
-            NR_JOBS=4
+            NR_JOBS=${{ env.NR_JOBS }}
+            CMAKE_BUILD_PARALLEL_LEVEL=${{ env.NR_JOBS }}
             CMAKE_BUILD_TYPE=${{ inputs.build_type }}
       - name: Build wheels (stable)
         if: ${{ inputs.full_build }}
@@ -137,7 +141,8 @@ jobs:
           CIBW_CONFIG_SETTINGS: cmake.build-type=${{ inputs.build_type }}
           CIBW_ENVIRONMENT: >-
             STORM_VERSION=${{ inputs.storm_version }}
-            NR_JOBS=4
+            NR_JOBS=${{ env.NR_JOBS }}
+            CMAKE_BUILD_PARALLEL_LEVEL=${{ env.NR_JOBS }}
             CMAKE_BUILD_TYPE=${{ inputs.build_type }}
       - uses: actions/upload-artifact@v7
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,8 @@ if (NOT storm_FOUND)
     endif()
 endif()
 
+message(STATUS "Stormpy - Building ${CMAKE_BUILD_TYPE} version.")
+
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/lib/stormpy")
 
 # This sets interprocedural optimization off as this leads to some problems on some systems

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ find_package(Boost 1.70 QUIET REQUIRED CONFIG)
 if (Boost_FOUND)
     if (${Boost_VERSION} VERSION_GREATER_EQUAL "1.81.0")
         message(STATUS "Stormpy - Using workaround for Boost >= 1.81")
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_PHOENIX_STL_TUPLE_H_")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_PHOENIX_STL_TUPLE_H_")
     endif()
 endif()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,16 +84,17 @@ sdist.include = [
 STORM_DIR_HINT=""
 ALLOW_STORM_SYSTEM="ON"
 ALLOW_STORM_FETCH="ON"
+STORM_GIT_REPO="https://github.com/stormchecker/storm.git"
+# Storm version should be synced with STORM_MIN_VERSION in CMakeLists.txt
+STORM_GIT_TAG="1.13.0"
 USE_STORM_DFT="ON"
 USE_STORM_GSPN="ON"
 USE_STORM_PARS="ON"
 USE_STORM_POMDP="ON"
 USE_CLN_NUMBERS="ON"
-COMPILE_WITH_CCACHE="ON"
 STORMPY_DISABLE_SIGNATURE_DOC="OFF"
-STORM_GIT_REPO="https://github.com/stormchecker/storm.git"
-# Storm version should be synced with STORM_MIN_VERSION in CMakeLists.txt
-STORM_GIT_TAG="1.13.0"
+COMPILE_WITH_CCACHE="ON"
+STORMPY_INFO_PRETEND_FETCH="OFF"
 
 
 [tool.scikit-build.metadata.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,10 @@ before-all = ".github/workflows/before-all-macos.sh"
 repair-wheel-command = "delocate-listdeps -vv --depending --all {wheel} && DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [tool.cibuildwheel.config-settings]
-"cmake.args" = ["-DSTORM_PORTABLE=ON", "-DALLOW_STORM_SYSTEM='ON'", "-DALLOW_STORM_FETCH='OFF'", "-DSTORMPY_INFO_PRETEND_FETCH='ON'"]
+# These override [tool.scikit-build.cmake.define] defaults when building via cibuildwheel.
+# Need to be in quotation marks.
+"cmake.define.ALLOW_STORM_FETCH" = "OFF"
+"cmake.define.STORMPY_INFO_PRETEND_FETCH" = "ON"
 
 [tool.black]
 line-length = 160

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ sdist.include = [
 ]
 
 [tool.scikit-build.cmake.define]
+# See CMakeLists.txt for descriptions of these options
 STORM_DIR_HINT=""
 ALLOW_STORM_SYSTEM="ON"
 ALLOW_STORM_FETCH="ON"
@@ -94,8 +95,8 @@ USE_STORM_POMDP="ON"
 USE_CLN_NUMBERS="ON"
 STORMPY_DISABLE_SIGNATURE_DOC="OFF"
 COMPILE_WITH_CCACHE="ON"
+# Override some flags in stormpy.info. Used for building release wheels via cibuildwheel
 STORMPY_INFO_PRETEND_FETCH="OFF"
-
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"


### PR DESCRIPTION
- Fixed cmake.args. In the old version, setting the build type overwrote all other options.
- Build wheels with multiple threads governed by NR_JOBS

Minor:
- Print CMAKE_BUILD_TYPE
- Removed quotation marks for cmake.args
- Use same ordering of cmake options in CMakeLists.txt and pyproject.yml