### PR TITLE
Towards generating good stubs: attempt at fixing C++ name leaks by first declaring, then defining

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,14 +332,28 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/pycarl/definitions.h.in ${CMAKE_C
 
 # Build stormpy
 ######
-# Build stormpy modules
-stormpy_module(core "." "${storm-counterexamples_INCLUDE_DIR}" storm-counterexamples)
+# Build the mutually dependent core bindings in one extension. The extension
+# registers the public native modules in two passes: all Python types first,
+# followed by their methods and free functions.
+build_stormpy_module(stormpy_bindings
+                     "." "bindings"
+                     "mod_bindings.cpp" "core/*.cpp"
+                     "${storm-counterexamples_INCLUDE_DIR}"
+                     "storm-counterexamples")
+file(GLOB_RECURSE STORMPY_BINDINGS_EXTRA_SOURCES
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/logic/*.cpp"
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/storage/*.cpp"
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/utility/*.cpp")
+target_sources(stormpy_bindings PRIVATE ${STORMPY_BINDINGS_EXTRA_SOURCES})
+target_sources(stormpy_bindings PRIVATE
+               "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_core.cpp"
+               "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_logic.cpp"
+               "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_storage.cpp"
+               "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_utility.cpp")
+target_compile_definitions(stormpy_bindings PRIVATE STORMPY_REGISTRATION_TWO_PASS)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/core_config.py.in ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/_config.py @ONLY)
 stormpy_module(info info "${storm-version-info_INCLUDE_DIR}" storm-version-info)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/info_config.py.in ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/info/_config.py @ONLY)
-stormpy_module(logic logic "" "")
-stormpy_module(storage storage "" "")
-stormpy_module(utility utility "" "")
 
 # Build optional stormpy modules
 stormpy_optional_module(dft "DFT")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,6 +294,7 @@ function(stormpy_optional_module MOD_NAME DESCRIPTION)
                              "mod_${MOD_NAME}.cpp" "${MOD_NAME}/*.cpp"
                              "${storm-${MOD_NAME}_INCLUDE_DIR}"
                              "storm-${MOD_NAME}")
+        target_compile_definitions("stormpy_${MOD_NAME}" PRIVATE STORMPY_REGISTRATION_TWO_PASS)
         MESSAGE(STATUS "Stormpy - Support for ${DESCRIPTION} found and included.")
     else()
         MESSAGE(WARNING "Stormpy - No support for ${DESCRIPTION}!")
@@ -307,6 +308,7 @@ function(build_pycarl_module MOD_NAME OUT_DIR OUT_NAME MOD_FILE SOURCE_PATH ADDI
                  "${MOD_FILE}" "${SOURCE_PATH}"
                  "${carl_INCLUDE_DIR};${ADDITIONAL_INCLUDES}"
                  "lib_carl;${ADDITIONAL_LIBS}")
+    target_compile_definitions(${MOD_NAME} PRIVATE STORMPY_REGISTRATION_TWO_PASS)
 endfunction(build_pycarl_module)
 function(pycarl_module MOD_NAME ADDITIONAL_INCLUDES ADDITIONAL_LIBS)
     build_pycarl_module("pycarl_${MOD_NAME}"

--- a/cmake/core_config.py.in
+++ b/cmake/core_config.py.in
@@ -8,3 +8,7 @@ Polynomial = pycarl.@PYCARL_RF_PACKAGE@.Polynomial
 FactorizedPolynomial = pycarl.@PYCARL_RF_PACKAGE@.FactorizedPolynomial
 RationalFunction = pycarl.@PYCARL_RF_PACKAGE@.RationalFunction
 FactorizedRationalFunction = pycarl.@PYCARL_RF_PACKAGE@.FactorizedRationalFunction
+
+# Register the formula type used by Storm's parametric graph analysis before
+# the native Storm APIs are bound.
+from stormpy.pycarl.@PYCARL_RF_PACKAGE@ import formula as _pycarl_formula

--- a/lib/stormpy/__init__.py
+++ b/lib/stormpy/__init__.py
@@ -1,6 +1,8 @@
 from ._config import *
 
-from . import _core
+from . import _bindings
+
+_core = _bindings._core
 from ._core import *
 from . import storage
 from .storage import *

--- a/lib/stormpy/logic/__init__.py
+++ b/lib/stormpy/logic/__init__.py
@@ -1,2 +1,4 @@
-from . import _logic
+import stormpy
+
+_logic = stormpy._bindings._logic
 from ._logic import *

--- a/lib/stormpy/storage/__init__.py
+++ b/lib/stormpy/storage/__init__.py
@@ -1,5 +1,6 @@
 import stormpy.utility
-from . import _storage
+
+_storage = stormpy._bindings._storage
 from ._storage import *
 from deprecated.sphinx import deprecated
 

--- a/lib/stormpy/utility/__init__.py
+++ b/lib/stormpy/utility/__init__.py
@@ -1,4 +1,6 @@
-from . import _utility
+import stormpy
+
+_utility = stormpy._bindings._utility
 from ._utility import *
 
 # Extend JSON container for simplified access

--- a/src/common.h
+++ b/src/common.h
@@ -8,7 +8,12 @@
 #include <pybind11/stl.h>
 #include <tuple>
 
+#ifdef STORMPY_REGISTRATION_TWO_PASS
+#include "src/registration.h"
+namespace py = stormpy::registration;
+#else
 namespace py = pybind11;
+#endif
 using namespace pybind11::literals;
 
 PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)

--- a/src/core/bisimulation.cpp
+++ b/src/core/bisimulation.cpp
@@ -4,10 +4,11 @@
 #include <storm/models/symbolic/StandardRewardModel.h>
 
 template<storm::dd::DdType DdType, typename ValueType>
-std::shared_ptr<storm::models::Model<ValueType>> performBisimulationMinimization(
-    std::shared_ptr<storm::models::symbolic::Model<DdType, ValueType>> const& model, std::vector<std::shared_ptr<storm::logic::Formula const>> const& formulas,
-    storm::storage::BisimulationType const& bisimulationType, storm::dd::bisimulation::QuotientFormat const& quotientFormat,
-    storm::dd::bisimulation::BisimulationOptions const& bisimulationOptions) {
+std::shared_ptr<storm::models::ModelBase> performBisimulationMinimization(std::shared_ptr<storm::models::symbolic::Model<DdType, ValueType>> const& model,
+                                                                          std::vector<std::shared_ptr<storm::logic::Formula const>> const& formulas,
+                                                                          storm::storage::BisimulationType const& bisimulationType,
+                                                                          storm::dd::bisimulation::QuotientFormat const& quotientFormat,
+                                                                          storm::dd::bisimulation::BisimulationOptions const& bisimulationOptions) {
     return storm::api::performBisimulationMinimization<DdType, ValueType, ValueType>(
         model, formulas, bisimulationType, storm::dd::bisimulation::SignatureMode::Eager, quotientFormat, bisimulationOptions);
 }
@@ -35,6 +36,21 @@ void define_bisimulation(py::module& m) {
     py::native_enum<storm::dd::bisimulation::QuotientFormat>(m, "QuotientFormat", "enum.Enum", "Return format of bisimulation quotient")
         .value("SPARSE", storm::dd::bisimulation::QuotientFormat::Sparse)
         .value("DD", storm::dd::bisimulation::QuotientFormat::Dd)
+        .finalize();
+
+    py::native_enum<storm::dd::bisimulation::ReuseMode>(m, "BisimulationReuseMode", "enum.Enum")
+        .value("NONE", storm::dd::bisimulation::ReuseMode::None)
+        .value("BLOCK_NUMBERS", storm::dd::bisimulation::ReuseMode::BlockNumbers)
+        .finalize();
+
+    py::native_enum<storm::dd::bisimulation::RefinementMode>(m, "BisimulationRefinementMode", "enum.Enum")
+        .value("FULL", storm::dd::bisimulation::RefinementMode::Full)
+        .value("CHANGED_STATES", storm::dd::bisimulation::RefinementMode::ChangedStates)
+        .finalize();
+
+    py::native_enum<storm::dd::bisimulation::InitialPartitionMode>(m, "BisimulationInitialPartitionMode", "enum.Enum")
+        .value("REGULAR", storm::dd::bisimulation::InitialPartitionMode::Regular)
+        .value("FINER", storm::dd::bisimulation::InitialPartitionMode::Finer)
         .finalize();
 
     py::class_<storm::dd::bisimulation::BisimulationOptions>(m, "BisimulationOptionsDd", "Options for Dd bisimulation")

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -180,6 +180,9 @@ void define_build_sparse_model_defs(py::module& m) {
         m.def("make_sparse_model_builder_exact", &storm::api::makeExplicitModelBuilder<storm::RationalNumber>, "Construct a builder instance",
               py::arg("model_description"), py::arg("options"), py::arg("action_mask") = nullptr,
               py::arg("exploration_options") = typename storm::builder::ExplicitModelBuilder<ValueType>::Options());
+        py::class_<storm::builder::ExplicitModelBuilder<storm::RationalNumber>>(m, "ExplicitExactModelBuilder", "Model builder for exact sparse models")
+            .def("build", &storm::builder::ExplicitModelBuilder<storm::RationalNumber>::build, "Build the model", py::call_guard<py::gil_scoped_release>())
+            .def("export_lookup", &storm::builder::ExplicitModelBuilder<storm::RationalNumber>::exportExplicitStateLookup, "Export a lookup model");
     }
 }
 
@@ -242,6 +245,9 @@ void define_build(py::module& m) {
              py::arg("new_value") = true);
 
     py::class_<storm::generator::ActionMask<double>, std::shared_ptr<storm::generator::ActionMask<double>>> actionmask(m, "ActionMaskDouble");
+    py::class_<storm::generator::ActionMask<storm::RationalNumber>, std::shared_ptr<storm::generator::ActionMask<storm::RationalNumber>>>(m, "ActionMaskExact");
+    py::class_<storm::generator::ActionMask<storm::RationalFunction>, std::shared_ptr<storm::generator::ActionMask<storm::RationalFunction>>>(
+        m, "ActionMaskParametric");
     py::class_<storm::generator::StateValuationFunctionMask<double>, std::shared_ptr<storm::generator::StateValuationFunctionMask<double>>> actfuncmask(
         m, "StateValuationFunctionActionMaskDouble", actionmask);
     actfuncmask.def(py::init<std::function<bool(storm::expressions::SimpleValuation const&, uint64_t)>>(), py::arg("f"));

--- a/src/gspn/gspn.cpp
+++ b/src/gspn/gspn.cpp
@@ -2,6 +2,7 @@
 
 #include <storm-gspn/storage/gspn/GSPN.h>
 #include <storm-gspn/storage/gspn/GspnBuilder.h>
+#include <storm-gspn/storage/gspn/Marking.h>
 #include <storm/io/file.h>
 #include <storm/settings/SettingsManager.h>
 
@@ -10,6 +11,7 @@
 using GSPN = storm::gspn::GSPN;
 using GSPNBuilder = storm::gspn::GspnBuilder;
 using LayoutInfo = storm::gspn::LayoutInfo;
+using Marking = storm::gspn::Marking;
 using Place = storm::gspn::Place;
 using TimedTransition = storm::gspn::TimedTransition<GSPN::RateType>;
 using ImmediateTransition = storm::gspn::ImmediateTransition<GSPN::WeightType>;
@@ -29,6 +31,17 @@ void gspnToFile(GSPN const& gspn, std::string const& filepath, bool toPnpro) {
 }
 
 void define_gspn(py::module& m) {
+    py::class_<Marking>(m, "Marking", "Token distribution over the places of a GSPN")
+        .def(py::init<uint_fast64_t const&, std::map<uint_fast64_t, uint_fast64_t> const&, uint_fast64_t const&>(), py::arg("number_of_places"),
+             py::arg("number_of_bits"), py::arg("number_of_total_bits"))
+        .def(py::init<uint_fast64_t const&, std::map<uint_fast64_t, uint_fast64_t> const&, storm::storage::BitVector const&>(), py::arg("number_of_places"),
+             py::arg("number_of_bits"), py::arg("bitvector"))
+        .def_property_readonly("number_of_places", &Marking::getNumberOfPlaces)
+        .def("set_number_of_tokens", &Marking::setNumberOfTokensAt, py::arg("place"), py::arg("number_of_tokens"))
+        .def("get_number_of_tokens", &Marking::getNumberOfTokensAt, py::arg("place"))
+        .def_property_readonly("bitvector", &Marking::getBitVector)
+        .def(py::self == py::self);
+
     // GSPN_Builder class
     py::class_<GSPNBuilder, std::shared_ptr<GSPNBuilder>>(m, "GSPNBuilder", "Generalized Stochastic Petri Net Builder")
         .def(py::init(), "Constructor")

--- a/src/mod_bindings.cpp
+++ b/src/mod_bindings.cpp
@@ -1,0 +1,54 @@
+#include "src/module_bindings.h"
+
+namespace {
+
+pybind11::module_ createModule(pybind11::module_ const& parent, char const* name, char const* doc) {
+    pybind11::object moduleType = pybind11::module_::import("types").attr("ModuleType");
+    pybind11::module_ result = moduleType(name, doc).cast<pybind11::module_>();
+    result.attr("__package__") = std::string(name).substr(0, std::string(name).rfind('.'));
+    result.attr("__loader__") = pybind11::none();
+    result.attr("__spec__") = pybind11::module_::import("importlib.machinery").attr("ModuleSpec")(name, pybind11::none());
+    if (pybind11::hasattr(parent, "__file__")) {
+        result.attr("__file__") = parent.attr("__file__");
+        result.attr("__spec__").attr("origin") = parent.attr("__file__");
+    }
+    pybind11::module_::import("sys").attr("modules")[pybind11::str(name)] = result;
+    return result;
+}
+
+void bindAll(pybind11::module_ const& core, pybind11::module_ const& storage, pybind11::module_ const& logic, pybind11::module_ const& utility,
+             py::Phase phase) {
+    py::module utilityBindings(utility, phase);
+    py::module storageBindings(storage, phase);
+    py::module logicBindings(logic, phase);
+    py::module coreBindings(core, phase);
+
+    stormpy::bindings::bindUtility(utilityBindings);
+    stormpy::bindings::bindStorage(storageBindings);
+    stormpy::bindings::bindLogic(logicBindings);
+    stormpy::bindings::bindCore(coreBindings);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(_bindings, m) {
+    m.doc() = "Native Storm bindings";
+
+#ifdef STORMPY_DISABLE_SIGNATURE_DOC
+    pybind11::options options;
+    options.disable_function_signatures();
+#endif
+
+    pybind11::module_ core = createModule(m, "stormpy._core", "Core Storm APIs");
+    pybind11::module_ storage = createModule(m, "stormpy.storage._storage", "Data structures in Storm");
+    pybind11::module_ logic = createModule(m, "stormpy.logic._logic", "Logic module for Storm");
+    pybind11::module_ utility = createModule(m, "stormpy.utility._utility", "Utilities for Storm");
+
+    m.attr("_core") = core;
+    m.attr("_storage") = storage;
+    m.attr("_logic") = logic;
+    m.attr("_utility") = utility;
+
+    bindAll(core, storage, logic, utility, py::Phase::Declare);
+    bindAll(core, storage, logic, utility, py::Phase::Define);
+}

--- a/src/mod_core.cpp
+++ b/src/mod_core.cpp
@@ -1,6 +1,5 @@
 #include <storm/adapters/IntervalAdapter.h>
 
-#include "src/common.h"
 #include "src/core/analysis.h"
 #include "src/core/bisimulation.h"
 #include "src/core/core.h"
@@ -12,15 +11,11 @@
 #include "src/core/result.h"
 #include "src/core/simulator.h"
 #include "src/core/transformation.h"
+#include "src/module_bindings.h"
 
-PYBIND11_MODULE(_core, m) {
-    m.doc() = "core";
+namespace stormpy::bindings {
 
-#ifdef STORMPY_DISABLE_SIGNATURE_DOC
-    py::options options;
-    options.disable_function_signatures();
-#endif
-
+void bindCore(py::module& m) {
     define_environment(m);
     define_core(m);
 
@@ -55,3 +50,5 @@ PYBIND11_MODULE(_core, m) {
     define_sparse_model_simulator<storm::RationalNumber>(m, "Exact");
     define_prism_program_simulator<double>(m, "Double");
 }
+
+}  // namespace stormpy::bindings

--- a/src/mod_dft.cpp
+++ b/src/mod_dft.cpp
@@ -8,14 +8,9 @@
 #include "src/dft/simulator.h"
 #include "src/dft/transformations.h"
 
-PYBIND11_MODULE(_dft, m) {
-    m.doc() = "Functionality for DFT analysis";
+namespace {
 
-#ifdef STORMPY_DISABLE_SIGNATURE_DOC
-    py::options options;
-    options.disable_function_signatures();
-#endif
-
+void bindDft(py::module& m) {
     define_symmetries(m);  // Must be before define_analysis_typed
     define_analysis(m);
     define_analysis_typed<double>(m, "_double");
@@ -36,4 +31,17 @@ PYBIND11_MODULE(_dft, m) {
     define_simulator_typed<double>(m, "_double");
     define_simulator_typed<storm::RationalFunction>(m, "_ratfunc");
     define_transformations(m);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(_dft, m) {
+    m.doc() = "Functionality for DFT analysis";
+
+#ifdef STORMPY_DISABLE_SIGNATURE_DOC
+    py::options options;
+    options.disable_function_signatures();
+#endif
+
+    py::bindModule(m, bindDft);
 }

--- a/src/mod_gspn.cpp
+++ b/src/mod_gspn.cpp
@@ -2,6 +2,15 @@
 #include "src/gspn/gspn.h"
 #include "src/gspn/gspn_io.h"
 
+namespace {
+
+void bindGspn(py::module& m) {
+    define_gspn(m);
+    define_gspn_io(m);
+}
+
+}  // namespace
+
 PYBIND11_MODULE(_gspn, m) {
     m.doc() = "Support for GSPNs";
 
@@ -10,6 +19,5 @@ PYBIND11_MODULE(_gspn, m) {
     options.disable_function_signatures();
 #endif
 
-    define_gspn(m);
-    define_gspn_io(m);
+    py::bindModule(m, bindGspn);
 }

--- a/src/mod_logic.cpp
+++ b/src/mod_logic.cpp
@@ -1,13 +1,10 @@
-#include "src/common.h"
 #include "src/logic/formulae.h"
+#include "src/module_bindings.h"
 
-PYBIND11_MODULE(_logic, m) {
-    m.doc() = "Logic module for Storm";
+namespace stormpy::bindings {
 
-#ifdef STORMPY_DISABLE_SIGNATURE_DOC
-    py::options options;
-    options.disable_function_signatures();
-#endif
-
+void bindLogic(py::module& m) {
     define_formulae(m);
 }
+
+}  // namespace stormpy::bindings

--- a/src/mod_pars.cpp
+++ b/src/mod_pars.cpp
@@ -3,6 +3,19 @@
 #include "src/pars/pars.h"
 #include "src/pars/pla.h"
 
+namespace {
+
+void bindPars(py::module& m) {
+    define_pars(m);
+    define_pla(m);
+    define_model_instantiator<double>(m);
+    define_model_instantiator<storm::RationalFunction>(m);
+    define_model_instantiation_checker<double>(m);
+    define_model_instantiation_checker<storm::RationalNumber>(m);
+}
+
+}  // namespace
+
 PYBIND11_MODULE(_pars, m) {
     m.doc() = "Functionality for parametric analysis";
 
@@ -11,10 +24,5 @@ PYBIND11_MODULE(_pars, m) {
     options.disable_function_signatures();
 #endif
 
-    define_pars(m);
-    define_pla(m);
-    define_model_instantiator<double>(m);
-    define_model_instantiator<storm::RationalFunction>(m);
-    define_model_instantiation_checker<double>(m);
-    define_model_instantiation_checker<storm::RationalNumber>(m);
+    py::bindModule(m, bindPars);
 }

--- a/src/mod_pomdp.cpp
+++ b/src/mod_pomdp.cpp
@@ -11,13 +11,9 @@
 #include "src/pomdp/tracker.h"
 #include "src/pomdp/transformations.h"
 
-PYBIND11_MODULE(_pomdp, m) {
-    m.doc() = "Functionality for POMDP analysis";
+namespace {
 
-#ifdef STORMPY_DISABLE_SIGNATURE_DOC
-    py::options options;
-    options.disable_function_signatures();
-#endif
+void bindPomdp(py::module& m) {
     define_tracker<double>(m, "Double");
     define_tracker<storm::RationalNumber>(m, "Exact");
     define_qualitative_policy_search<double>(m, "Double");
@@ -38,4 +34,17 @@ PYBIND11_MODULE(_pomdp, m) {
     define_belief_exploration<double>(m, "Double");
     define_verimon_generator<double>(m, "Double");
     define_verimon_generator<storm::RationalNumber>(m, "Exact");
+}
+
+}  // namespace
+
+PYBIND11_MODULE(_pomdp, m) {
+    m.doc() = "Functionality for POMDP analysis";
+
+#ifdef STORMPY_DISABLE_SIGNATURE_DOC
+    py::options options;
+    options.disable_function_signatures();
+#endif
+
+    py::bindModule(m, bindPomdp);
 }

--- a/src/mod_storage.cpp
+++ b/src/mod_storage.cpp
@@ -1,7 +1,7 @@
 #include <storm/adapters/IntervalAdapter.h>
 #include <storm/storage/dd/DdType.h>
 
-#include "src/common.h"
+#include "src/module_bindings.h"
 #include "src/storage/bitvector.h"
 #include "src/storage/choiceorigins.h"
 #include "src/storage/dd.h"
@@ -21,17 +21,14 @@
 #include "src/storage/umb.h"
 #include "src/storage/valuation.h"
 
-PYBIND11_MODULE(_storage, m) {
-    m.doc() = "Data structures in Storm";
+namespace stormpy::bindings {
 
-#ifdef STORMPY_DISABLE_SIGNATURE_DOC
-    py::options options;
-    options.disable_function_signatures();
-#endif
-
+void bindStorage(py::module& m) {
     define_bitvector(m);
     auto ddSylvan = define_dd<storm::dd::DdType::Sylvan>(m, "Sylvan");
     define_dd_typed<storm::dd::DdType::Sylvan, double>(m, "Sylvan", "_Double", ddSylvan);
+    define_dd_typed<storm::dd::DdType::Sylvan, storm::RationalNumber>(m, "Sylvan", "_Exact", ddSylvan);
+    define_dd_typed<storm::dd::DdType::Sylvan, storm::RationalFunction>(m, "Sylvan", "_Parametric", ddSylvan);
     define_dd_nt(m);
     define_model(m);
     define_sparse_model<double>(m, "");
@@ -47,6 +44,7 @@ PYBIND11_MODULE(_storage, m) {
     define_sparse_matrix<storm::Interval>(m, "Interval");
     define_sparse_matrix<storm::RationalInterval>(m, "RationalInterval");
     define_sparse_matrix<storm::RationalFunction>(m, "Parametric");
+    define_sparse_matrix<storm::storage::sparse::state_type>(m, "StateType");
     define_sparse_matrix_nt(m);
     define_symbolic_model<storm::dd::DdType::Sylvan, double>(m, "Sylvan");
     define_symbolic_model<storm::dd::DdType::Sylvan, storm::RationalNumber>(m, "SylvanExact");
@@ -76,6 +74,7 @@ PYBIND11_MODULE(_storage, m) {
     define_distribution<storm::RationalNumber>(m, "Exact");
     define_distribution<storm::Interval>(m, "Interval");
     define_distribution<storm::RationalInterval>(m, "RationalInterval");
+    define_distribution<storm::RationalFunction>(m, "Parametric");
     define_sparse_model_components<double>(m, "");
     define_sparse_model_components<storm::RationalNumber>(m, "Exact");
     define_sparse_model_components<storm::Interval>(m, "Interval");
@@ -92,3 +91,5 @@ PYBIND11_MODULE(_storage, m) {
     define_maximal_end_component_decomposition<storm::RationalFunction>(m, "_ratfunc");
     define_umb(m);
 }
+
+}  // namespace stormpy::bindings

--- a/src/mod_utility.cpp
+++ b/src/mod_utility.cpp
@@ -1,20 +1,15 @@
 #include <storm/adapters/RationalNumberAdapter.h>
 
-#include "src/common.h"
+#include "src/module_bindings.h"
 #include "src/utility/chrono.h"
 #include "src/utility/json.h"
 #include "src/utility/kwekMehlhorn.h"
 #include "src/utility/shortestPaths.h"
 #include "src/utility/smtsolver.h"
 
-PYBIND11_MODULE(_utility, m) {
-    m.doc() = "Utilities for Storm";
+namespace stormpy::bindings {
 
-#ifdef STORMPY_DISABLE_SIGNATURE_DOC
-    py::options options;
-    options.disable_function_signatures();
-#endif
-
+void bindUtility(py::module& m) {
     define_ksp(m);
     define_smt(m);
     define_chrono(m);
@@ -22,3 +17,5 @@ PYBIND11_MODULE(_utility, m) {
     define_json<storm::RationalNumber>(m, "Rational");
     define_kwek_mehlhorn<storm::RationalNumber>(m, "");
 }
+
+}  // namespace stormpy::bindings

--- a/src/module_bindings.h
+++ b/src/module_bindings.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "src/common.h"
+
+namespace stormpy::bindings {
+
+void bindCore(py::module& module);
+void bindLogic(py::module& module);
+void bindStorage(py::module& module);
+void bindUtility(py::module& module);
+
+}  // namespace stormpy::bindings

--- a/src/pars/pla.cpp
+++ b/src/pars/pla.cpp
@@ -2,6 +2,7 @@
 
 #include <storm-pars/api/region.h>
 #include <storm-pars/modelchecker/instantiation/SparseDtmcInstantiationModelChecker.h>
+#include <storm-pars/modelchecker/region/RegionSplitEstimateKind.h>
 #include <storm-pars/modelchecker/region/SparseDtmcParameterLiftingModelChecker.h>
 #include <storm-pars/modelchecker/region/SparseMdpParameterLiftingModelChecker.h>
 #include <storm/api/verification.h>
@@ -96,6 +97,13 @@ std::set<storm::Polynomial> gatherDerivatives(storm::models::sparse::Model<storm
 
 // Define python bindings
 void define_pla(py::module& m) {
+    py::native_enum<storm::modelchecker::RegionSplitEstimateKind>(m, "RegionSplitEstimateKind", "enum.Enum", "Methods for estimating region splits")
+        .value("DISTANCE", storm::modelchecker::RegionSplitEstimateKind::Distance)
+        .value("STATE_VALUE_DELTA", storm::modelchecker::RegionSplitEstimateKind::StateValueDelta)
+        .value("STATE_VALUE_DELTA_WEIGHTED", storm::modelchecker::RegionSplitEstimateKind::StateValueDeltaWeighted)
+        .value("DERIVATIVE", storm::modelchecker::RegionSplitEstimateKind::Derivative)
+        .finalize();
+
     // RegionResult
     py::native_enum<storm::modelchecker::RegionResult>(m, "RegionResult", "enum.Enum", "Types of region check results")
         .value("EXISTSSAT", storm::modelchecker::RegionResult::ExistsSat)

--- a/src/pycarl/mod_cln.cpp
+++ b/src/pycarl/mod_cln.cpp
@@ -10,11 +10,9 @@
 #include "src/pycarl/typed_core/term.h"
 #include "src/pycarl/types.h"
 
-PYBIND11_MODULE(_cln, m) {
-    m.attr("__name__") = "stormpy.pycarl.cln";
+namespace {
 
-    m.doc() = "pycarl core cln-typed data and functions";
-
+void bindCln(py::module& m) {
     define_cln_integer(m);
     define_cln_rational(m);
     define_term(m);
@@ -26,4 +24,13 @@ PYBIND11_MODULE(_cln, m) {
     define_factorizedrationalfunction(m);
 
     define_interval<Rational>(m);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(_cln, m) {
+    m.attr("__name__") = "stormpy.pycarl.cln";
+    m.doc() = "pycarl core cln-typed data and functions";
+
+    py::bindModule(m, bindCln);
 }

--- a/src/pycarl/mod_core.cpp
+++ b/src/pycarl/mod_core.cpp
@@ -4,14 +4,22 @@
 #include "src/pycarl/core/variable.h"
 #include "src/pycarl/typed_core/interval.h"
 
-PYBIND11_MODULE(_pycarl_core, m) {
-    m.doc() = "pycarl core untyped functions";
+namespace {
 
+void bindCore(py::module& m) {
     define_variabletype(m);
     define_variable(m);
     define_monomial(m);
     define_boundtype(m);
     define_interval<double>(m);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(_pycarl_core, m) {
+    m.doc() = "pycarl core untyped functions";
+
+    py::bindModule(m, bindCore);
 
     py::register_exception<NoPickling>(m, "NoPicklingSupport");
 }

--- a/src/pycarl/mod_formula.cpp
+++ b/src/pycarl/mod_formula.cpp
@@ -3,6 +3,15 @@
 #include "src/pycarl/formula/formula_type.h"
 #include "src/pycarl/formula/relation.h"
 
+namespace {
+
+void bindFormula(py::module& m) {
+    define_relation(m);
+    define_formula_type(m);
+}
+
+}  // namespace
+
 PYBIND11_MODULE(_formula, m) {
     m.attr("__name__") = "stormpy.pycarl.formula";
     m.doc() = "pycarl formula untyped functions";
@@ -10,6 +19,5 @@ PYBIND11_MODULE(_formula, m) {
     // Constraint relies on Rational
     m.import("stormpy.pycarl");
 
-    define_relation(m);
-    define_formula_type(m);
+    py::bindModule(m, bindFormula);
 }

--- a/src/pycarl/mod_gmp.cpp
+++ b/src/pycarl/mod_gmp.cpp
@@ -10,10 +10,9 @@
 #include "src/pycarl/typed_core/term.h"
 #include "src/pycarl/types.h"
 
-PYBIND11_MODULE(_gmp, m) {
-    m.attr("__name__") = "stormpy.pycarl.gmp";
-    m.doc() = "pycarl core gmp-typed data and functions";
+namespace {
 
+void bindGmp(py::module& m) {
     define_gmp_integer(m);
     define_gmp_rational(m);
     define_term(m);
@@ -25,4 +24,13 @@ PYBIND11_MODULE(_gmp, m) {
     define_factorizedrationalfunction(m);
 
     define_interval<Rational>(m);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(_gmp, m) {
+    m.attr("__name__") = "stormpy.pycarl.gmp";
+    m.doc() = "pycarl core gmp-typed data and functions";
+
+    py::bindModule(m, bindGmp);
 }

--- a/src/pycarl/mod_typed_formula.cpp
+++ b/src/pycarl/mod_typed_formula.cpp
@@ -3,15 +3,27 @@
 #include "src/pycarl/typed_formula/constraint.h"
 #include "src/pycarl/typed_formula/formula.h"
 
+namespace {
+
+void bindTypedFormula(py::module& m) {
+    define_constraint(m);
+    define_simple_constraint(m);
+    define_formula(m);
+}
+
+}  // namespace
+
 PYBIND11_MODULE(_formula, m) {
-    m.attr("__name__") = "stormpy.pycarl.formula";
+#ifdef PYCARL_USE_CLN
+    m.attr("__name__") = "stormpy.pycarl.cln.formula";
+#else
+    m.attr("__name__") = "stormpy.pycarl.gmp.formula";
+#endif
     m.doc() = "pycarl formula typed functions";
 
     // Constraint relies on Rational
     m.import("stormpy.pycarl");
     m.import("stormpy.pycarl.formula");
 
-    define_constraint(m);
-    define_simple_constraint(m);
-    define_formula(m);
+    py::bindModule(m, bindTypedFormula);
 }

--- a/src/pycarl/typed_core/rational.cpp
+++ b/src/pycarl/typed_core/rational.cpp
@@ -183,7 +183,9 @@ void define_cln_rational(py::module& m) {
             return h(v);
         });
 
-    py::implicitly_convertible<carl::uint, cln::cl_RA>();
+    if (m.phase() == py::Phase::Define) {
+        py::implicitly_convertible<carl::uint, cln::cl_RA>();
+    }
 #endif
 }
 
@@ -298,6 +300,8 @@ void define_gmp_rational(py::module& m) {
             return h(v);
         });
 
-    py::implicitly_convertible<carl::uint, mpq_class>();
+    if (m.phase() == py::Phase::Define) {
+        py::implicitly_convertible<carl::uint, mpq_class>();
+    }
 #endif
 }

--- a/src/registration.h
+++ b/src/registration.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+namespace stormpy::registration {
+
+// This facade lets the existing binding functions participate in two global
+// passes without duplicating their declarations. The declaration pass creates
+// every Python class and enum; the definition pass looks those classes up and
+// attaches methods and free functions. Binding argument expressions are still
+// evaluated in both passes, so binding functions must otherwise be declarative.
+using namespace pybind11;
+
+enum class Phase { Declare, Define };
+
+class module {
+   public:
+    module(pybind11::module_ const& implementation, Phase phase) :implementation_(implementation), phase_(phase) {}
+
+    Phase phase() const {
+        return phase_;
+    }
+    pybind11::module_ const& raw() const {
+        return implementation_;
+    }
+
+    template<typename... Args>
+    void def(Args&&... args) {
+        if (phase_ == Phase::Define) {
+            implementation_.def(std::forward<Args>(args)...);
+        }
+    }
+
+   private:
+    pybind11::module_ implementation_;
+    Phase phase_;
+};
+
+template<typename Type, typename... Options>
+class class_;
+
+template<typename Value>
+Value const& unwrap(Value const& value) {
+    return value;
+}
+
+template<typename Type, typename... Options>
+pybind11::handle unwrap(class_<Type, Options...> const& value);
+
+template<typename Type, typename... Options>
+class class_ {
+   public:
+    using RawClass = pybind11::class_<Type, Options...>;
+
+    template<typename... Extra>
+    class_(module const& parent, char const* name, Extra const&... extra) : implementation_(acquire(parent, name, extra...)), phase_(parent.phase()) {}
+
+    Phase phase() const {
+        return phase_;
+    }
+    RawClass const& raw() const {
+        return implementation_;
+    }
+
+#define STORMPY_FORWARD_CLASS_METHOD(method)                     \
+    template<typename... Args>                                   \
+    class_& method(Args&&... args) {                             \
+        if (phase_ == Phase::Define) {                           \
+            implementation_.method(std::forward<Args>(args)...); \
+        }                                                        \
+        return *this;                                            \
+    }
+
+    STORMPY_FORWARD_CLASS_METHOD(def)
+    STORMPY_FORWARD_CLASS_METHOD(def_property)
+    STORMPY_FORWARD_CLASS_METHOD(def_property_readonly)
+    STORMPY_FORWARD_CLASS_METHOD(def_readonly)
+    STORMPY_FORWARD_CLASS_METHOD(def_readwrite)
+    STORMPY_FORWARD_CLASS_METHOD(def_static)
+
+#undef STORMPY_FORWARD_CLASS_METHOD
+
+   private:
+    template<typename... Extra>
+    static RawClass acquire(module const& parent, char const* name, Extra const&... extra) {
+        if (parent.phase() == Phase::Declare) {
+            return RawClass(parent.raw(), name, unwrap(extra)...);
+        }
+        // Reuse the Python type registered in the declaration pass. Constructing
+        // another pybind11::class_ would attempt to register the C++ type twice.
+        return pybind11::reinterpret_borrow<RawClass>(parent.raw().attr(name));
+    }
+
+    RawClass implementation_;
+    Phase phase_;
+};
+
+template<typename Type, typename... Options>
+pybind11::handle unwrap(class_<Type, Options...> const& value) {
+    return value.raw();
+}
+
+template<typename EnumType>
+class native_enum {
+   public:
+    template<typename Parent>
+    native_enum(Parent const& parent, char const* name, char const* nativeTypeName, char const* classDoc = "") {
+        if (parent.phase() == Phase::Declare) {
+            implementation_ = std::make_unique<pybind11::native_enum<EnumType>>(parent.raw(), name, nativeTypeName, classDoc);
+        }
+    }
+
+    native_enum& value(char const* name, EnumType value, char const* doc = nullptr) {
+        if (implementation_) {
+            implementation_->value(name, value, doc);
+        }
+        return *this;
+    }
+
+    native_enum& export_values() {
+        if (implementation_) {
+            implementation_->export_values();
+        }
+        return *this;
+    }
+
+    void finalize() {
+        if (implementation_) {
+            implementation_->finalize();
+        }
+    }
+
+   private:
+    std::unique_ptr<pybind11::native_enum<EnumType>> implementation_;
+};
+
+}  // namespace stormpy::registration

--- a/src/registration.h
+++ b/src/registration.h
@@ -25,6 +25,10 @@ class module {
         return implementation_;
     }
 
+    auto attr(char const* name) const {
+        return implementation_.attr(name);
+    }
+
     template<typename... Args>
     void def(Args&&... args) {
         if (phase_ == Phase::Define) {
@@ -36,6 +40,15 @@ class module {
     pybind11::module_ implementation_;
     Phase phase_;
 };
+
+template<typename BindingFunction>
+void bindModule(pybind11::module_ const& implementation, BindingFunction&& bind) {
+    module declarations(implementation, Phase::Declare);
+    bind(declarations);
+
+    module definitions(implementation, Phase::Define);
+    bind(definitions);
+}
 
 template<typename Type, typename... Options>
 class class_;

--- a/src/storage/dd.cpp
+++ b/src/storage/dd.cpp
@@ -1,5 +1,7 @@
 #include "dd.h"
 
+#include <storm/adapters/RationalFunctionAdapter.h>
+#include <storm/adapters/RationalNumberAdapter.h>
 #include <storm/storage/dd/Add.h>
 #include <storm/storage/dd/Bdd.h>
 #include <storm/storage/dd/Dd.h>
@@ -55,3 +57,7 @@ void define_dd_nt(py::module& m) {
 template py::class_<storm::dd::Dd<storm::dd::DdType::Sylvan>> define_dd<storm::dd::DdType::Sylvan>(py::module& m, std::string const& libstring);
 template void define_dd_typed<storm::dd::DdType::Sylvan, double>(py::module&, std::string const&, std::string const&,
                                                                  py::class_<storm::dd::Dd<storm::dd::DdType::Sylvan>> const&);
+template void define_dd_typed<storm::dd::DdType::Sylvan, storm::RationalNumber>(py::module&, std::string const&, std::string const&,
+                                                                                py::class_<storm::dd::Dd<storm::dd::DdType::Sylvan>> const&);
+template void define_dd_typed<storm::dd::DdType::Sylvan, storm::RationalFunction>(py::module&, std::string const&, std::string const&,
+                                                                                  py::class_<storm::dd::Dd<storm::dd::DdType::Sylvan>> const&);

--- a/src/storage/distribution.cpp
+++ b/src/storage/distribution.cpp
@@ -1,6 +1,7 @@
 #include "distribution.h"
 
 #include <storm/adapters/IntervalAdapter.h>
+#include <storm/adapters/RationalFunctionAdapter.h>
 #include <storm/adapters/RationalNumberAdapter.h>
 #include <storm/storage/Distribution.h>
 
@@ -19,3 +20,4 @@ template void define_distribution<double>(py::module&, std::string vt_suffix);
 template void define_distribution<storm::RationalNumber>(py::module&, std::string vt_suffix);
 template void define_distribution<storm::Interval>(py::module&, std::string vt_suffix);
 template void define_distribution<storm::RationalInterval>(py::module&, std::string vt_suffix);
+template void define_distribution<storm::RationalFunction>(py::module&, std::string vt_suffix);

--- a/src/storage/jani.cpp
+++ b/src/storage/jani.cpp
@@ -163,8 +163,17 @@ void define_jani(py::module& m) {
         .def_property_readonly("is_continuous_type", &JaniType::isContinuousType)
         .def("__str__", &JaniType::getStringRepresentation);
     py::class_<BasicType, std::shared_ptr<BasicType>> basicType(m, "BasicType", "A basic type in JANI", janiType);
+    py::native_enum<BasicType::Type>(basicType, "Type", "enum.Enum")
+        .value("BOOL", BasicType::Type::Bool)
+        .value("INT", BasicType::Type::Int)
+        .value("REAL", BasicType::Type::Real)
+        .finalize();
     basicType.def_property_readonly("inner_type", &BasicType::get, "the inner type");
     py::class_<BoundedType, std::shared_ptr<BoundedType>> boundedType(m, "BoundedType", "A bounded type in JANI", janiType);
+    py::native_enum<BoundedType::BaseType>(boundedType, "BaseType", "enum.Enum")
+        .value("INT", BoundedType::BaseType::Int)
+        .value("REAL", BoundedType::BaseType::Real)
+        .finalize();
     boundedType.def_property_readonly("base_type", &BoundedType::getBaseType, "the base type")
         .def_property_readonly(
             "lower_bound", [](const BoundedType& tp) -> storm::expressions::Expression const& { return tp.getLowerBound(); }, "the lower bound")
@@ -219,6 +228,15 @@ void define_jani(py::module& m) {
 }
 
 void define_jani_transformers(py::module& m) {
+    py::class_<JaniLocationExpander::NewIndices>(m, "JaniLocationExpansionNewIndices")
+        .def_readonly("location_variable_value_map", &JaniLocationExpander::NewIndices::locationVariableValueMap)
+        .def_readonly("variable_domain", &JaniLocationExpander::NewIndices::variableDomain)
+        .def_readonly("excluded_locations_to_new_indices", &JaniLocationExpander::NewIndices::excludedLocationsToNewIndices);
+
+    py::class_<JaniLocationExpander::ReturnType>(m, "JaniLocationExpansionResult")
+        .def_readonly("model", &JaniLocationExpander::ReturnType::newModel)
+        .def_readonly("new_indices", &JaniLocationExpander::ReturnType::newIndices);
+
     py::class_<JaniLocationExpander>(m, "JaniLocationExpander", "A transformer for Jani expanding variables into locations")
         .def(py::init<Model const&>(), py::arg("model"))
         .def("transform", &JaniLocationExpander::transform, py::arg("automaton_name"), py::arg("variable_name"));

--- a/src/storage/matrix.cpp
+++ b/src/storage/matrix.cpp
@@ -4,6 +4,7 @@
 #include <storm/adapters/RationalFunctionAdapter.h>
 #include <storm/storage/BitVector.h>
 #include <storm/storage/SparseMatrix.h>
+#include <storm/storage/sparse/StateType.h>
 #include <storm/utility/graph.h>
 
 #include "src/helpers.h"
@@ -184,3 +185,4 @@ template void define_sparse_matrix<storm::RationalNumber>(py::module& m, std::st
 template void define_sparse_matrix<storm::Interval>(py::module& m, std::string const& vtSuffix);
 template void define_sparse_matrix<storm::RationalInterval>(py::module& m, std::string const& vtSuffix);
 template void define_sparse_matrix<storm::RationalFunction>(py::module& m, std::string const& vtSuffix);
+template void define_sparse_matrix<storm::storage::sparse::state_type>(py::module& m, std::string const& vtSuffix);

--- a/tests/test_registration_order.py
+++ b/tests/test_registration_order.py
@@ -5,6 +5,24 @@ import pytest
 
 import stormpy
 
+NATIVE_MODULE_NAMES = (
+    "stormpy._core",
+    "stormpy.storage._storage",
+    "stormpy.logic._logic",
+    "stormpy.utility._utility",
+    "stormpy.dft._dft",
+    "stormpy.gspn._gspn",
+    "stormpy.pars._pars",
+    "stormpy.pomdp._pomdp",
+    "stormpy.info._info",
+    "stormpy.pycarl._pycarl_core",
+    "stormpy.pycarl.gmp._gmp",
+    "stormpy.pycarl.cln._cln",
+    "stormpy.pycarl.formula._formula",
+    "stormpy.pycarl.gmp.formula._formula",
+    "stormpy.pycarl.cln.formula._formula",
+)
+
 
 def test_native_modules_keep_their_public_names():
     expected_modules = {
@@ -45,17 +63,32 @@ def test_cross_module_signatures_use_python_type_names(binding):
     assert "stormpy." in signature
 
 
-def test_native_callable_signatures_do_not_contain_cpp_qualified_names():
-    modules = (stormpy._core, stormpy.storage._storage, stormpy.logic._logic, stormpy.utility._utility)
+@pytest.mark.parametrize("module_name", NATIVE_MODULE_NAMES)
+def test_native_callable_signatures_do_not_contain_cpp_qualified_names(module_name):
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as error:
+        pytest.skip(str(error))
+
     signature_lines = []
 
-    for module in modules:
-        for _, obj in inspect.getmembers(module):
-            members = inspect.getmembers(obj) if inspect.isclass(obj) else ((obj.__name__, obj),) if callable(obj) else ()
-            for _, member in members:
-                doc = getattr(member, "__doc__", None)
-                if doc:
-                    signature_lines.extend(line.strip() for line in doc.splitlines() if " -> " in line and not line.lstrip().startswith(":"))
+    for _, obj in inspect.getmembers(module):
+        members = inspect.getmembers(obj) if inspect.isclass(obj) else ((obj.__name__, obj),) if callable(obj) else ()
+        for _, member in members:
+            doc = getattr(member, "__doc__", None)
+            if doc:
+                signature_lines.extend(line.strip() for line in doc.splitlines() if " -> " in line and not line.lstrip().startswith(":"))
 
     leaked_signatures = [line for line in signature_lines if "::" in line]
     assert leaked_signatures == []
+
+
+@pytest.mark.parametrize("backend", ("gmp", "cln"))
+def test_typed_pycarl_formulas_use_their_backend_module(backend):
+    try:
+        module = importlib.import_module(f"stormpy.pycarl.{backend}.formula")
+    except ImportError as error:
+        pytest.skip(str(error))
+
+    assert module.Formula.__module__ == module.__name__
+    assert module.Constraint.__module__ == module.__name__

--- a/tests/test_registration_order.py
+++ b/tests/test_registration_order.py
@@ -1,0 +1,61 @@
+import importlib
+import inspect
+
+import pytest
+
+import stormpy
+
+
+def test_native_modules_keep_their_public_names():
+    expected_modules = {
+        "stormpy._core": stormpy._core,
+        "stormpy.storage._storage": stormpy.storage._storage,
+        "stormpy.logic._logic": stormpy.logic._logic,
+        "stormpy.utility._utility": stormpy.utility._utility,
+    }
+
+    for name, module in expected_modules.items():
+        assert module.__name__ == name
+        assert module.__spec__.name == name
+        assert module.__file__ == stormpy._bindings.__file__
+        assert importlib.import_module(name) is module
+
+
+@pytest.mark.parametrize(
+    "binding",
+    [
+        stormpy.ExpressionManager.create_boolean,
+        stormpy.storage._storage._ModelBase._as_sparse_dtmc,
+        stormpy.storage.JaniModel.get_automaton,
+        stormpy.storage.PrismProgram.to_jani,
+        stormpy.storage.JaniLocationExpander.transform,
+        stormpy.storage.SchedulerChoiceParametric.get_choice,
+        stormpy._core._build_sparse_model_from_symbolic_description,
+        stormpy._core._perform_symbolic_bisimulation,
+        stormpy._core.make_sparse_model_builder_exact,
+        stormpy._core.SymbolicExactQuantitativeCheckResult.get_values,
+        stormpy._core.parse_properties_for_prism_program,
+        stormpy.utility.SmtSolver.add,
+    ],
+)
+def test_cross_module_signatures_use_python_type_names(binding):
+    signature = binding.__doc__.splitlines()[0]
+
+    assert "::" not in signature
+    assert "stormpy." in signature
+
+
+def test_native_callable_signatures_do_not_contain_cpp_qualified_names():
+    modules = (stormpy._core, stormpy.storage._storage, stormpy.logic._logic, stormpy.utility._utility)
+    signature_lines = []
+
+    for module in modules:
+        for _, obj in inspect.getmembers(module):
+            members = inspect.getmembers(obj) if inspect.isclass(obj) else ((obj.__name__, obj),) if callable(obj) else ()
+            for _, member in members:
+                doc = getattr(member, "__doc__", None)
+                if doc:
+                    signature_lines.extend(line.strip() for line in doc.splitlines() if " -> " in line and not line.lstrip().startswith(":"))
+
+    leaked_signatures = [line for line in signature_lines if "::" in line]
+    assert leaked_signatures == []


### PR DESCRIPTION
Currently, the pybind11 leaks C++ type names, which makes it very difficult to generate stubs. This PR fixes this, but I'm not sure if this is the best way to do it yet. We first declare everything and then define the methods. Because the core, storage, logic, and utility modules all reference each other, this PR creates a new `mod_bindings.cpp` that technically is a joint module containing all these modules (the visible module paths themselves stay the same). All of the extension modules are fixed to do declare-then-define as well, but these modules don't reference each other, so that has just been done in the module directly. A couple of individual fixes were needed for definitions that were missing.

On top of this PR, it should be quite straightforward to generate stubs :)