### PR TITLE
Migrate `unique_ptr` and `shared_ptr` uses to `py::smart_holder`

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -11,7 +11,4 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
-PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T const>)
-
 #include "src/boost.h"

--- a/src/core/analysis.cpp
+++ b/src/core/analysis.cpp
@@ -5,8 +5,7 @@
 // Define python bindings
 void define_graph_constraints(py::module& m) {
     // ConstraintCollector
-    py::class_<storm::analysis::ConstraintCollector<storm::RationalFunction>, std::shared_ptr<storm::analysis::ConstraintCollector<storm::RationalFunction>>>(
-        m, "ConstraintCollector", "Collector for constraints on parametric Markov chains")
+    py::classh<storm::analysis::ConstraintCollector<storm::RationalFunction>>(m, "ConstraintCollector", "Collector for constraints on parametric Markov chains")
         .def(py::init<storm::models::sparse::Model<storm::RationalFunction> const&>(), py::arg("model"))
         .def_property_readonly("wellformed_constraints", &storm::analysis::ConstraintCollector<storm::RationalFunction>::getWellformedConstraints,
                                "Get the constraints ensuring a wellformed model")

--- a/src/core/bisimulation.cpp
+++ b/src/core/bisimulation.cpp
@@ -37,7 +37,7 @@ void define_bisimulation(py::module& m) {
         .value("DD", storm::dd::bisimulation::QuotientFormat::Dd)
         .finalize();
 
-    py::class_<storm::dd::bisimulation::BisimulationOptions>(m, "BisimulationOptionsDd", "Options for Dd bisimulation")
+    py::classh<storm::dd::bisimulation::BisimulationOptions>(m, "BisimulationOptionsDd", "Options for Dd bisimulation")
         .def(py::init<>(), "Create")
         .def_readwrite("reuse_mode", &storm::dd::bisimulation::BisimulationOptions::reuseMode, "Reuse mode")
         .def_readwrite("refinement_mode", &storm::dd::bisimulation::BisimulationOptions::refinementMode, "Refinement mode")

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -144,7 +144,7 @@ void define_build_sparse_model_defs(py::module& m) {
           ("Build the " + desc + "model from DRN" + (std::is_same_v<ValueType, storm::RationalFunction> ? " (parametric)" : "")).c_str(), py::arg("file"),
           py::arg("options") = storm::parser::DirectEncodingParserOptions());
 
-    py::class_<typename storm::builder::ExplicitModelBuilder<ValueType>::Options>(m, ("Explicit" + classType + "ModelBuilderOptions").c_str(),
+    py::classh<typename storm::builder::ExplicitModelBuilder<ValueType>::Options>(m, ("Explicit" + classType + "ModelBuilderOptions").c_str(),
                                                                                   "Options for the explicit model builder")
         .def(py::init<>(), "Create")
         .def_readwrite("exploration_order", &storm::builder::ExplicitModelBuilder<ValueType>::Options::explorationOrder,
@@ -164,7 +164,7 @@ void define_build_sparse_model_defs(py::module& m) {
         m.def("make_sparse_model_builder", &storm::api::makeExplicitModelBuilder<double>, "Construct a builder instance", py::arg("model_description"),
               py::arg("options"), py::arg("action_mask") = nullptr,
               py::arg("exploration_options") = typename storm::builder::ExplicitModelBuilder<ValueType>::Options());
-        py::class_<storm::builder::ExplicitModelBuilder<double>>(m, "ExplicitModelBuilder", "Model builder for sparse models")
+        py::classh<storm::builder::ExplicitModelBuilder<double>>(m, "ExplicitModelBuilder", "Model builder for sparse models")
             .def("build", &storm::builder::ExplicitModelBuilder<double>::build, "Build the model", py::call_guard<py::gil_scoped_release>())
             .def("export_lookup", &storm::builder::ExplicitModelBuilder<double>::exportExplicitStateLookup, "Export a lookup model");
     } else if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) {
@@ -174,7 +174,7 @@ void define_build_sparse_model_defs(py::module& m) {
         m.def("make_sparse_model_builder_parametric", &storm::api::makeExplicitModelBuilder<storm::RationalFunction>, "Construct a builder instance",
               py::arg("model_description"), py::arg("options"), py::arg("action_mask") = nullptr,
               py::arg("exploration_options") = typename storm::builder::ExplicitModelBuilder<ValueType>::Options());
-        py::class_<storm::builder::ExplicitModelBuilder<storm::RationalFunction>>(m, "ExplicitParametricModelBuilder", "Model builder for sparse models")
+        py::classh<storm::builder::ExplicitModelBuilder<storm::RationalFunction>>(m, "ExplicitParametricModelBuilder", "Model builder for sparse models")
             .def("build", &storm::builder::ExplicitModelBuilder<storm::RationalFunction>::build, "Build the model", py::call_guard<py::gil_scoped_release>())
             .def("export_lookup", &storm::builder::ExplicitModelBuilder<storm::RationalFunction>::exportExplicitStateLookup, "Export a lookup model");
     } else if constexpr (std::is_same_v<ValueType, storm::RationalNumber>) {
@@ -185,7 +185,7 @@ void define_build_sparse_model_defs(py::module& m) {
 }
 
 void define_build(py::module& m) {
-    py::class_<storm::parser::DirectEncodingParserOptions>(m, "DirectEncodingParserOptions", "Options for the .drn parser")
+    py::classh<storm::parser::DirectEncodingParserOptions>(m, "DirectEncodingParserOptions", "Options for the .drn parser")
         .def(py::init<>(), "initialise")
         .def_readwrite("build_choice_labels", &storm::parser::DirectEncodingParserOptions::buildChoiceLabeling, "Build with choice labels");
 
@@ -194,7 +194,7 @@ void define_build(py::module& m) {
         .value("BFS", storm::builder::ExplorationOrder::Bfs)
         .finalize();
 
-    py::class_<typename storm::parser::ExplicitModelParserOptions>(m, "ExplicitModelParserOptions", "Options for the explicit model parser")
+    py::classh<typename storm::parser::ExplicitModelParserOptions>(m, "ExplicitModelParserOptions", "Options for the explicit model parser")
         .def(py::init<>(), "Create")
         .def_readwrite("fix_deadlocks", &storm::parser::ExplicitModelParserOptions::fixDeadlocks,
                        "If set, deadlocks states will be fixed by adding a self-loop with probability 1.")
@@ -207,7 +207,7 @@ void define_build(py::module& m) {
     define_build_sparse_model_defs<storm::Interval>(m);
     define_build_sparse_model_defs<storm::RationalInterval>(m);
 
-    py::class_<storm::builder::ExplicitStateLookup<uint32_t>>(m, "ExplicitStateLookup", "Lookup model for states")
+    py::classh<storm::builder::ExplicitStateLookup<uint32_t>>(m, "ExplicitStateLookup", "Lookup model for states")
         .def(
             "lookup",
             [](storm::builder::ExplicitStateLookup<uint32_t> const& lookup,
@@ -223,7 +223,7 @@ void define_build(py::module& m) {
 
         ;
 
-    py::class_<storm::builder::BuilderOptions>(m, "BuilderOptions", "Options for building process")
+    py::classh<storm::builder::BuilderOptions>(m, "BuilderOptions", "Options for building process")
         .def(py::init<std::vector<std::shared_ptr<storm::logic::Formula const>> const&>(), "Initialise with formulae to preserve", py::arg("formulae"))
         .def(py::init<bool, bool>(), "Initialise without formulae", py::arg("build_all_reward_models") = true, py::arg("build_all_labels") = true)
         .def_property_readonly("preserved_label_names", &storm::builder::BuilderOptions::getLabelNames, "Labels preserved")
@@ -242,9 +242,8 @@ void define_build(py::module& m) {
         .def("set_build_all_reward_models", &storm::builder::BuilderOptions::setBuildAllRewardModels, "Build with all reward models",
              py::arg("new_value") = true);
 
-    py::class_<storm::generator::ActionMask<double>, std::shared_ptr<storm::generator::ActionMask<double>>> actionmask(m, "ActionMaskDouble");
-    py::class_<storm::generator::StateValuationFunctionMask<double>, std::shared_ptr<storm::generator::StateValuationFunctionMask<double>>> actfuncmask(
-        m, "StateValuationFunctionActionMaskDouble", actionmask);
+    py::classh<storm::generator::ActionMask<double>> actionmask(m, "ActionMaskDouble");
+    py::classh<storm::generator::StateValuationFunctionMask<double>> actfuncmask(m, "StateValuationFunctionActionMaskDouble", actionmask);
     actfuncmask.def(py::init<std::function<bool(storm::expressions::SimpleValuation const&, uint64_t)>>(), py::arg("f"));
 }
 
@@ -296,7 +295,7 @@ void define_export_drn(py::module& m) {
 }
 
 void define_export(py::module& m) {
-    py::class_<storm::io::DirectEncodingExporterOptions>(m, "DirectEncodingExporterOptions")
+    py::classh<storm::io::DirectEncodingExporterOptions>(m, "DirectEncodingExporterOptions")
         .def(py::init<>())
         .def_readwrite("allow_placeholders", &storm::io::DirectEncodingExporterOptions::allowPlaceholders)
         .def_readwrite("outputPrecision", &storm::io::DirectEncodingExporterOptions::outputPrecision);

--- a/src/core/counterexample.cpp
+++ b/src/core/counterexample.cpp
@@ -9,7 +9,7 @@ using namespace storm::counterexamples;
 void define_counterexamples(py::module& m) {
     using FlatSet = boost::container::flat_set<uint64_t, std::less<uint64_t>, boost::container::new_allocator<uint64_t>>;
 
-    py::class_<FlatSet>(m, "FlatSet", "Container to pass to program")
+    py::classh<FlatSet>(m, "FlatSet", "Container to pass to program")
         .def(py::init<>())
         .def(py::init<FlatSet>(), "other"_a)
         .def("insert", [](FlatSet& flatset, uint64_t value) { flatset.insert(value); })
@@ -37,7 +37,7 @@ void define_counterexamples(py::module& m) {
 
     using CexGeneratorStats = SMTMinimalLabelSetGenerator<double>::GeneratorStats;
 
-    py::class_<CexGeneratorStats>(m, "SMTCounterExampleGeneratorStats", "Stats for highlevel counterexample generation")
+    py::classh<CexGeneratorStats>(m, "SMTCounterExampleGeneratorStats", "Stats for highlevel counterexample generation")
         .def(py::init<>())
         .def_readonly("analysis_time", &CexGeneratorStats::analysisTime)
         .def_readonly("setup_time", &CexGeneratorStats::setupTime)
@@ -47,7 +47,7 @@ void define_counterexamples(py::module& m) {
         .def_readonly("iterations", &CexGeneratorStats::iterations);
 
     using CexGeneratorOptions = SMTMinimalLabelSetGenerator<double>::Options;
-    py::class_<CexGeneratorOptions>(m, "SMTCounterExampleGeneratorOptions", "Options for highlevel counterexample generation")
+    py::classh<CexGeneratorOptions>(m, "SMTCounterExampleGeneratorOptions", "Options for highlevel counterexample generation")
         .def(py::init<>())
         .def_readwrite("check_threshold_feasible", &CexGeneratorOptions::checkThresholdFeasible)
         .def_readwrite("encode_reachability", &CexGeneratorOptions::encodeReachability)
@@ -57,7 +57,7 @@ void define_counterexamples(py::module& m) {
         .def_readwrite("maximum_counterexamples", &CexGeneratorOptions::maximumCounterexamples)
         .def_readwrite("continue_after_first_counterexample", &CexGeneratorOptions::continueAfterFirstCounterexampleUntil)
         .def_readwrite("maximum_iterations_after_counterexample", &CexGeneratorOptions::maximumExtraIterations);
-    py::class_<SMTMinimalLabelSetGenerator<double>>(m, "SMTCounterExampleGenerator", "Highlevel Counterexample Generator with SMT as backend")
+    py::classh<SMTMinimalLabelSetGenerator<double>>(m, "SMTCounterExampleGenerator", "Highlevel Counterexample Generator with SMT as backend")
         .def_static("precompute", &SMTMinimalLabelSetGenerator<double>::precompute, "Precompute input for counterexample generation", py::arg("env"),
                     py::arg("symbolic_model"), py::arg("model"), py::arg("formula"))
         .def_static("build", &SMTMinimalLabelSetGenerator<double>::computeCounterexampleLabelSet, "Compute counterexample", py::arg("env"), py::arg("stats"),
@@ -66,7 +66,7 @@ void define_counterexamples(py::module& m) {
         ;
 
     using CexInput = SMTMinimalLabelSetGenerator<double>::CexInput;
-    py::class_<CexInput>(m, "SMTCounterExampleInput", "Precomputed input for counterexample generation")
+    py::classh<CexInput>(m, "SMTCounterExampleInput", "Precomputed input for counterexample generation")
         .def("add_reward_and_threshold", &CexInput::addRewardThresholdCombination, "add another reward structure and threshold", py::arg("reward_name"),
              py::arg("threshold"));
 }

--- a/src/core/environment.cpp
+++ b/src/core/environment.cpp
@@ -111,7 +111,7 @@ void define_environment(py::module& m) {
         .value("counter", storm::storage::SchedulerClass::MemoryPattern::Counter)
         .finalize();
 
-    py::class_<storm::storage::SchedulerClass>(m, "SchedulerClass", "Scheduler class restriction")
+    py::classh<storm::storage::SchedulerClass>(m, "SchedulerClass", "Scheduler class restriction")
         .def(py::init<>())
         .def_property("deterministic", &storm::storage::SchedulerClass::isDeterministic,
                       [](storm::storage::SchedulerClass& sc, bool v) { sc.setIsDeterministic(v); })
@@ -133,7 +133,7 @@ void define_environment(py::module& m) {
         .def("set_memory_pattern", [](storm::storage::SchedulerClass& sc, storm::storage::SchedulerClass::MemoryPattern p) { sc.setMemoryPattern(p); })
         .def("set_positional", &storm::storage::SchedulerClass::setPositional);
 
-    py::class_<storm::Environment>(m, "Environment", "Environment")
+    py::classh<storm::Environment>(m, "Environment", "Environment")
         .def(py::init<>(), "Construct default environment")
         .def_property_readonly(
             "solver_environment", [](storm::Environment& env) -> auto& { return env.solver(); }, "solver part of environment")
@@ -141,7 +141,7 @@ void define_environment(py::module& m) {
             "model_checker_environment", [](storm::Environment& env) -> auto& { return env.modelchecker(); }, "model checker part of environment")
         .def_property_readonly("dd_environment", [](storm::Environment& env) -> auto& { return env.dd(); }, "dd part of environment");
 
-    py::class_<storm::ConditionalModelCheckerEnvironment>(m, "ConditionalModelCheckerEnvironment", "Environment for conditional model checking")
+    py::classh<storm::ConditionalModelCheckerEnvironment>(m, "ConditionalModelCheckerEnvironment", "Environment for conditional model checking")
         .def_property("algorithm", &storm::ConditionalModelCheckerEnvironment::getAlgorithm, &storm::ConditionalModelCheckerEnvironment::setAlgorithm,
                       "algorithm for conditional model checking")
         .def_property(
@@ -151,7 +151,7 @@ void define_environment(py::module& m) {
         .def_property("relative", &storm::ConditionalModelCheckerEnvironment::isRelativePrecision,
                       &storm::ConditionalModelCheckerEnvironment::setRelativePrecision, "whether the precision is relative");
 
-    py::class_<storm::ModelCheckerEnvironment>(m, "ModelCheckerEnvironment", "Environment for the model checker")
+    py::classh<storm::ModelCheckerEnvironment>(m, "ModelCheckerEnvironment", "Environment for the model checker")
         .def_property("steady_state_distribution_algorithm", &storm::ModelCheckerEnvironment::getSteadyStateDistributionAlgorithm,
                       &storm::ModelCheckerEnvironment::setSteadyStateDistributionAlgorithm, "steady state distribution algorithm used")
         .def_property(
@@ -175,7 +175,7 @@ void define_environment(py::module& m) {
             "multi", [](storm::ModelCheckerEnvironment& env) -> storm::MultiObjectiveModelCheckerEnvironment& { return env.multi(); },
             py::return_value_policy::reference, "Access multi-objective sub-environment");
 
-    py::class_<storm::MultiObjectiveModelCheckerEnvironment>(m, "MultiObjectiveModelCheckerEnvironment", "Environment for multi-objective model checking")
+    py::classh<storm::MultiObjectiveModelCheckerEnvironment>(m, "MultiObjectiveModelCheckerEnvironment", "Environment for multi-objective model checking")
         .def_property(
             "method", [](storm::MultiObjectiveModelCheckerEnvironment const& env) { return env.getMethod(); },
             &storm::MultiObjectiveModelCheckerEnvironment::setMethod, "multi-objective model checking method")
@@ -262,7 +262,7 @@ void define_environment(py::module& m) {
         .def_property("print_results", &storm::MultiObjectiveModelCheckerEnvironment::isPrintResultsSet,
                       &storm::MultiObjectiveModelCheckerEnvironment::setPrintResults);
 
-    py::class_<storm::SolverEnvironment>(m, "SolverEnvironment", "Environment for solvers")
+    py::classh<storm::SolverEnvironment>(m, "SolverEnvironment", "Environment for solvers")
         .def("set_force_sound", &storm::SolverEnvironment::setForceSoundness, "force soundness", py::arg("new_value") = true)
         .def("set_force_exact", &storm::SolverEnvironment::setForceExact, "force exact solving", py::arg("new_value") = true)
         .def("set_linear_equation_solver_type", &storm::SolverEnvironment::setLinearEquationSolverType, "set solver type to use", py::arg("new_value"),
@@ -270,27 +270,27 @@ void define_environment(py::module& m) {
         .def_property_readonly("minmax_solver_environment", [](storm::SolverEnvironment& senv) -> auto& { return senv.minMax(); })
         .def_property_readonly("native_solver_environment", [](storm::SolverEnvironment& senv) -> auto& { return senv.native(); });
 
-    py::class_<storm::NativeSolverEnvironment>(m, "NativeSolverEnvironment", "Environment for Native solvers")
+    py::classh<storm::NativeSolverEnvironment>(m, "NativeSolverEnvironment", "Environment for Native solvers")
         .def_property("method", &storm::NativeSolverEnvironment::getMethod,
                       [](storm::NativeSolverEnvironment& nsenv, storm::solver::NativeLinearEquationSolverMethod const& m) { nsenv.setMethod(m); })
         .def_property("maximum_iterations", &storm::NativeSolverEnvironment::getMaximalNumberOfIterations,
                       [](storm::NativeSolverEnvironment& nsenv, uint64_t iters) { nsenv.setMaximalNumberOfIterations(iters); })
         .def_property("precision", &storm::NativeSolverEnvironment::getPrecision, &storm::NativeSolverEnvironment::setPrecision);
 
-    py::class_<storm::MinMaxSolverEnvironment>(m, "MinMaxSolverEnvironment", "Environment for Min-Max-Solvers")
+    py::classh<storm::MinMaxSolverEnvironment>(m, "MinMaxSolverEnvironment", "Environment for Min-Max-Solvers")
         .def_property("method", &storm::MinMaxSolverEnvironment::getMethod,
                       [](storm::MinMaxSolverEnvironment& mmenv, storm::solver::MinMaxMethod const& m) { mmenv.setMethod(m, false); })
         .def_property("precision", &storm::MinMaxSolverEnvironment::getPrecision, &storm::MinMaxSolverEnvironment::setPrecision);
 
-    py::class_<storm::DdEnvironment>(m, "DdEnvironment", "Environment for DD libraries")
+    py::classh<storm::DdEnvironment>(m, "DdEnvironment", "Environment for DD libraries")
         .def_property_readonly("sylvan", [](storm::DdEnvironment& senv) -> auto& { return senv.sylvan(); })
         .def_property_readonly("cudd", [](storm::DdEnvironment& senv) -> auto& { return senv.cudd(); });
 
-    py::class_<storm::SylvanDdManagerEnvironment>(m, "SylvanDdManagerEnvironment", "Environment for Sylvan Dd manager")
+    py::classh<storm::SylvanDdManagerEnvironment>(m, "SylvanDdManagerEnvironment", "Environment for Sylvan Dd manager")
         .def_property("maximal_memory", &storm::SylvanDdManagerEnvironment::getMaximalMemory, &storm::SylvanDdManagerEnvironment::setMaximalMemory)
         .def_property("number_threads", &storm::SylvanDdManagerEnvironment::getNumberOfThreads, &storm::SylvanDdManagerEnvironment::setNumberOfThreads);
 
-    py::class_<storm::CuddDdManagerEnvironment>(m, "CuddDdManagerEnvironment", "Environment for CUDD Dd manager")
+    py::classh<storm::CuddDdManagerEnvironment>(m, "CuddDdManagerEnvironment", "Environment for CUDD Dd manager")
         .def_property("maximal_memory", &storm::CuddDdManagerEnvironment::getMaximalMemory, &storm::CuddDdManagerEnvironment::setMaximalMemory)
         .def_property("constant_precision", &storm::CuddDdManagerEnvironment::getConstantPrecision, &storm::CuddDdManagerEnvironment::setConstantPrecision)
         .def_property("reordering_enabled", &storm::CuddDdManagerEnvironment::isReorderingEnabled, &storm::CuddDdManagerEnvironment::setReorderingEnabled)

--- a/src/core/input.cpp
+++ b/src/core/input.cpp
@@ -6,7 +6,7 @@
 #include "src/helpers.h"
 
 void define_property(py::module& m) {
-    py::class_<storm::jani::Property>(m, "Property", "Property")
+    py::classh<storm::jani::Property>(m, "Property", "Property")
         .def(py::init<std::string const&, std::shared_ptr<storm::logic::Formula const> const&, std::set<storm::expressions::Variable> const&,
                       std::string const&>(),
              "Construct property from formula", py::arg("name"), py::arg("formula"), py::arg("undefined_constants") = std::set<storm::expressions::Variable>(),
@@ -73,7 +73,7 @@ void define_input(py::module& m) {
         .finalize();
 
     // SymbolicModelDescription
-    py::class_<storm::storage::SymbolicModelDescription>(m, "SymbolicModelDescription", "Symbolic description of model")
+    py::classh<storm::storage::SymbolicModelDescription>(m, "SymbolicModelDescription", "Symbolic description of model")
         .def(py::init<storm::prism::Program const&>(), "Construct from Prism program", py::arg("prism_program"))
         .def(py::init<storm::jani::Model const&>(), "Construct from Jani model", py::arg("jani_model"))
         .def_property_readonly("is_prism_program", &storm::storage::SymbolicModelDescription::isPrismProgram, "Flag if program is in Prism format")

--- a/src/core/modelchecking.cpp
+++ b/src/core/modelchecking.cpp
@@ -145,7 +145,7 @@ storm::storage::BitVector getReachableStates(storm::models::sparse::Model<ValueT
 template<typename ValueType>
 void define_check_task(py::module& m, std::string const& name) {
     // CheckTask
-    py::class_<CheckTask<ValueType>, std::shared_ptr<CheckTask<ValueType>>>(m, name.c_str(), "Task for model checking")
+    py::classh<CheckTask<ValueType>>(m, name.c_str(), "Task for model checking")
         .def(py::init<storm::logic::Formula const&, bool>(), py::arg("formula"), py::arg("only_initial_states") = false)
         .def("set_produce_schedulers", &CheckTask<ValueType>::setProduceSchedulers, "Set whether schedulers should be produced (if possible)",
              py::arg("produce_schedulers") = true)
@@ -207,9 +207,8 @@ void define_modelchecking_mdefs(py::module& m) {
 }
 
 void define_modelchecking(py::module& m) {
-    py::class_<storm::modelchecker::ModelCheckerHint, std::shared_ptr<storm::modelchecker::ModelCheckerHint>> mchint(
-        m, "ModelCheckerHint", "Information that may accelerate the model checking process");
-    py::class_<storm::modelchecker::ExplicitModelCheckerHint<double>>(m, "ExplicitModelCheckerHintDouble",
+    py::classh<storm::modelchecker::ModelCheckerHint> mchint(m, "ModelCheckerHint", "Information that may accelerate the model checking process");
+    py::classh<storm::modelchecker::ExplicitModelCheckerHint<double>>(m, "ExplicitModelCheckerHintDouble",
                                                                       "Information that may accelerate an explicit state model checker", mchint)
         .def(py::init<>())
         .def("set_scheduler_hint",

--- a/src/core/multiobjective.cpp
+++ b/src/core/multiobjective.cpp
@@ -27,8 +27,7 @@ void define_multiobjective(py::module& m, std::string const& vtSuffix) {
           py::arg("model"), py::arg("formula"), py::arg("compute_scheduler") = false);
 
     using PcaaWeightVectorChecker = storm::modelchecker::multiobjective::PcaaWeightVectorChecker<storm::models::sparse::Mdp<ValueType>>;
-    py::class_<PcaaWeightVectorChecker, std::unique_ptr<PcaaWeightVectorChecker>> weightedObjectiveMdpModelChecker(
-        m, ("WeightedObjectiveMdpModelChecker" + vtSuffix).c_str());
+    py::classh<PcaaWeightVectorChecker> weightedObjectiveMdpModelChecker(m, ("WeightedObjectiveMdpModelChecker" + vtSuffix).c_str());
     weightedObjectiveMdpModelChecker.def("check", &PcaaWeightVectorChecker::check, py::arg("env"), py::arg("weight_vector"))
         .def("get_achievable_point", &PcaaWeightVectorChecker::getAchievablePoint)
         .def("get_optimal_weighted_sum", &PcaaWeightVectorChecker::getOptimalWeightedSum,

--- a/src/core/result.cpp
+++ b/src/core/result.cpp
@@ -27,8 +27,7 @@ std::shared_ptr<storm::modelchecker::QualitativeCheckResult> createFilterSymboli
 }
 
 template<typename ValueType>
-void define_result_as_explicit(py::class_<storm::modelchecker::CheckResult, std::shared_ptr<storm::modelchecker::CheckResult>>& checkResult,
-                               std::string const& vtSuffix) {
+void define_result_as_explicit(py::classh<storm::modelchecker::CheckResult>& checkResult, std::string const& vtSuffix) {
     checkResult.def(("as_explicit" + vtSuffix + "_qualitative").c_str(),
                     [](storm::modelchecker::CheckResult const& result) { return result.template asExplicitQualitativeCheckResult<ValueType>(); },
                     "Convert into explicit qualitative result");
@@ -40,8 +39,7 @@ void define_result_as_explicit(py::class_<storm::modelchecker::CheckResult, std:
 // Define python bindings
 void define_result(py::module& m) {
     // CheckResult
-    py::class_<storm::modelchecker::CheckResult, std::shared_ptr<storm::modelchecker::CheckResult>> checkResult(m, "_CheckResult",
-                                                                                                                "Base class for all modelchecking results");
+    py::classh<storm::modelchecker::CheckResult> checkResult(m, "_CheckResult", "Base class for all modelchecking results");
     checkResult.def_property_readonly("_symbolic", &storm::modelchecker::CheckResult::isSymbolic, "Flag if result is symbolic")
         .def_property_readonly("_hybrid", &storm::modelchecker::CheckResult::isHybrid, "Flag if result is hybrid")
         .def_property_readonly("_quantitative", &storm::modelchecker::CheckResult::isQuantitative, "Flag if result is quantitative")
@@ -70,11 +68,10 @@ void define_result(py::module& m) {
         });
 
     // QualitativeCheckResult
-    py::class_<storm::modelchecker::QualitativeCheckResult, std::shared_ptr<storm::modelchecker::QualitativeCheckResult>> qualitativeCheckResult(
-        m, "_QualitativeCheckResult", "Abstract class for qualitative model checking results", checkResult);
+    py::classh<storm::modelchecker::QualitativeCheckResult> qualitativeCheckResult(m, "_QualitativeCheckResult",
+                                                                                   "Abstract class for qualitative model checking results", checkResult);
 
-    py::class_<storm::modelchecker::SymbolicQualitativeCheckResult<storm::dd::DdType::Sylvan>,
-               std::shared_ptr<storm::modelchecker::SymbolicQualitativeCheckResult<storm::dd::DdType::Sylvan>>>(
+    py::classh<storm::modelchecker::SymbolicQualitativeCheckResult<storm::dd::DdType::Sylvan>>(
         m, "SymbolicQualitativeCheckResult", "Symbolic qualitative model checking result", qualitativeCheckResult)
         .def("get_truth_values", &storm::modelchecker::SymbolicQualitativeCheckResult<storm::dd::DdType::Sylvan>::getTruthValuesVector,
              "Get Dd representing the truth values");
@@ -82,9 +79,8 @@ void define_result(py::module& m) {
 
 template<typename ValueType>
 void define_typed_result(py::module& m, std::string const& vtSuffix) {
-    py::class_<storm::modelchecker::ExplicitQualitativeCheckResult<ValueType>, std::shared_ptr<storm::modelchecker::ExplicitQualitativeCheckResult<ValueType>>,
-               storm::modelchecker::QualitativeCheckResult>(m, ("Explicit" + vtSuffix + "QualitativeCheckResult").c_str(),
-                                                            "Explicit qualitative model checking result")
+    py::classh<storm::modelchecker::ExplicitQualitativeCheckResult<ValueType>, storm::modelchecker::QualitativeCheckResult>(
+        m, ("Explicit" + vtSuffix + "QualitativeCheckResult").c_str(), "Explicit qualitative model checking result")
         .def(
             "at",
             [](storm::modelchecker::ExplicitQualitativeCheckResult<ValueType> const& result, storm::storage::sparse::state_type state) {
@@ -96,15 +92,13 @@ void define_typed_result(py::module& m, std::string const& vtSuffix) {
         .def_property_readonly(
             "scheduler", [](storm::modelchecker::ExplicitQualitativeCheckResult<ValueType> const& res) { return res.getScheduler(); }, "Get scheduler");
 
-    py::class_<storm::modelchecker::QuantitativeCheckResult<ValueType>, std::shared_ptr<storm::modelchecker::QuantitativeCheckResult<ValueType>>,
-               storm::modelchecker::CheckResult>
-        quantitativeCheckResult(m, ("_" + vtSuffix + "QuantitativeCheckResult").c_str(), "Abstract class for quantitative model checking results");
+    py::classh<storm::modelchecker::QuantitativeCheckResult<ValueType>, storm::modelchecker::CheckResult> quantitativeCheckResult(
+        m, ("_" + vtSuffix + "QuantitativeCheckResult").c_str(), "Abstract class for quantitative model checking results");
     quantitativeCheckResult.def_property_readonly("min", &storm::modelchecker::QuantitativeCheckResult<ValueType>::getMin, "Minimal value")
         .def_property_readonly("max", &storm::modelchecker::QuantitativeCheckResult<ValueType>::getMax, "Maximal value");
 
-    py::class_<storm::modelchecker::ExplicitQuantitativeCheckResult<ValueType>,
-               std::shared_ptr<storm::modelchecker::ExplicitQuantitativeCheckResult<ValueType>>>(
-        m, ("Explicit" + vtSuffix + "QuantitativeCheckResult").c_str(), "Explicit quantitative model checking result", quantitativeCheckResult)
+    py::classh<storm::modelchecker::ExplicitQuantitativeCheckResult<ValueType>>(m, ("Explicit" + vtSuffix + "QuantitativeCheckResult").c_str(),
+                                                                                "Explicit quantitative model checking result", quantitativeCheckResult)
         .def(py::init<std::vector<ValueType>>(), py::arg("values"))
         .def(
             "at",
@@ -118,8 +112,7 @@ void define_typed_result(py::module& m, std::string const& vtSuffix) {
         .def_property_readonly(
             "scheduler", [](storm::modelchecker::ExplicitQuantitativeCheckResult<ValueType> const& res) { return res.getScheduler(); }, "get scheduler");
 
-    py::class_<storm::modelchecker::SymbolicQuantitativeCheckResult<storm::dd::DdType::Sylvan, ValueType>,
-               std::shared_ptr<storm::modelchecker::SymbolicQuantitativeCheckResult<storm::dd::DdType::Sylvan, ValueType>>>(
+    py::classh<storm::modelchecker::SymbolicQuantitativeCheckResult<storm::dd::DdType::Sylvan, ValueType>>(
         m, ("Symbolic" + vtSuffix + "QuantitativeCheckResult").c_str(), "Symbolic quantitative model checking result", quantitativeCheckResult)
         .def("clone",
              [](storm::modelchecker::SymbolicQuantitativeCheckResult<storm::dd::DdType::Sylvan, ValueType> const& dd) {
@@ -127,22 +120,19 @@ void define_typed_result(py::module& m, std::string const& vtSuffix) {
              })
         .def("get_values", &storm::modelchecker::SymbolicQuantitativeCheckResult<storm::dd::DdType::Sylvan, ValueType>::getValueVector);
 
-    py::class_<storm::modelchecker::HybridQuantitativeCheckResult<storm::dd::DdType::Sylvan, ValueType>,
-               std::shared_ptr<storm::modelchecker::HybridQuantitativeCheckResult<storm::dd::DdType::Sylvan, ValueType>>>(
+    py::classh<storm::modelchecker::HybridQuantitativeCheckResult<storm::dd::DdType::Sylvan, ValueType>>(
         m, ("Hybrid" + vtSuffix + "QuantitativeCheckResult").c_str(), "Hybrid quantitative model checking result", quantitativeCheckResult)
         .def("get_values", &storm::modelchecker::HybridQuantitativeCheckResult<storm::dd::DdType::Sylvan, ValueType>::getExplicitValueVector,
              "Get model checking result values for all states");
 
     if constexpr (std::is_same_v<ValueType, double> || std::is_same_v<ValueType, storm::RationalNumber>) {
-        py::class_<storm::modelchecker::ParetoCurveCheckResult<ValueType>, std::shared_ptr<storm::modelchecker::ParetoCurveCheckResult<ValueType>>,
-                   storm::modelchecker::CheckResult>
-            pccheckresult(m, (vtSuffix + "ParetoCurveCheckResult").c_str(), "Result for multiobjective model checking");
+        py::classh<storm::modelchecker::ParetoCurveCheckResult<ValueType>, storm::modelchecker::CheckResult> pccheckresult(
+            m, (vtSuffix + "ParetoCurveCheckResult").c_str(), "Result for multiobjective model checking");
         pccheckresult.def("get_underapproximation", &storm::modelchecker::ParetoCurveCheckResult<ValueType>::getUnderApproximation)
             .def("get_overapproximation", &storm::modelchecker::ParetoCurveCheckResult<ValueType>::getOverApproximation);
 
-        py::class_<storm::modelchecker::ExplicitParetoCurveCheckResult<ValueType>,
-                   std::shared_ptr<storm::modelchecker::ExplicitParetoCurveCheckResult<ValueType>>>
-            epccheckresult(m, ("Explicit" + vtSuffix + "ParetoCurveCheckResult").c_str(), "Result for explicit multiobjective model checking", pccheckresult);
+        py::classh<storm::modelchecker::ExplicitParetoCurveCheckResult<ValueType>> epccheckresult(
+            m, ("Explicit" + vtSuffix + "ParetoCurveCheckResult").c_str(), "Result for explicit multiobjective model checking", pccheckresult);
 
         m.def(("create_filter_symbolic" + vtSuffix).c_str(), &createFilterSymbolic<storm::dd::DdType::Sylvan, ValueType>,
               "Creates a filter for the given states and a symbolic model", py::arg("model"), py::arg("states"));

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -9,7 +9,7 @@ using PLSim = storm::simulator::DiscreteTimePrismProgramSimulator<ValueType>;
 
 template<typename ValueType>
 void define_sparse_model_simulator(py::module& m, std::string const& vtSuffix) {
-    py::class_<storm::simulator::DiscreteTimeSparseModelSimulator<ValueType>> dtsmsd(m, ("_DiscreteTimeSparseModelSimulator" + vtSuffix).c_str(),
+    py::classh<storm::simulator::DiscreteTimeSparseModelSimulator<ValueType>> dtsmsd(m, ("_DiscreteTimeSparseModelSimulator" + vtSuffix).c_str(),
                                                                                      "Simulator for sparse discrete-time models in memory (for ValueType)");
     dtsmsd.def(py::init<storm::models::sparse::Model<ValueType> const&>());
     dtsmsd.def("set_seed", &storm::simulator::DiscreteTimeSparseModelSimulator<ValueType>::setSeed, py::arg("seed"));
@@ -22,7 +22,7 @@ void define_sparse_model_simulator(py::module& m, std::string const& vtSuffix) {
 
 template<typename ValueType>
 void define_prism_program_simulator(py::module& m, std::string const& vtSuffix) {
-    py::class_<storm::simulator::DiscreteTimePrismProgramSimulator<ValueType>> dtpps(m, ("_DiscreteTimePrismProgramSimulator" + vtSuffix).c_str(),
+    py::classh<storm::simulator::DiscreteTimePrismProgramSimulator<ValueType>> dtpps(m, ("_DiscreteTimePrismProgramSimulator" + vtSuffix).c_str(),
                                                                                      "Simulator for prism programs");
     dtpps.def(py::init<storm::prism::Program const&, storm::builder::BuilderOptions const&>(), py::arg("program"), py::arg("options"));
     dtpps.def("set_seed", &storm::simulator::DiscreteTimePrismProgramSimulator<ValueType>::setSeed, py::arg("seed"));

--- a/src/core/transformation.cpp
+++ b/src/core/transformation.cpp
@@ -55,7 +55,7 @@ void define_transformation(py::module& m) {
     define_transformation_mdef<double>(m);
     define_transformation_mdef<storm::RationalFunction>(m);
 
-    py::class_<storm::transformer::SubsystemBuilderOptions>(m, "SubsystemBuilderOptions", "Options for constructing the subsystem")
+    py::classh<storm::transformer::SubsystemBuilderOptions>(m, "SubsystemBuilderOptions", "Options for constructing the subsystem")
         .def(py::init<>())
         .def_readwrite("check_transitions_outside", &storm::transformer::SubsystemBuilderOptions::checkTransitionsOutside)
         .def_readwrite("build_state_mapping", &storm::transformer::SubsystemBuilderOptions::buildStateMapping)
@@ -74,7 +74,7 @@ void define_transformation(py::module& m) {
 
 template<typename ValueType>
 void define_transformation_typed(py::module& m, std::string const& vtSuffix) {
-    py::class_<storm::transformer::SubsystemBuilderReturnType<ValueType>>(m, ("SubsystemBuilderReturnType" + vtSuffix).c_str(),
+    py::classh<storm::transformer::SubsystemBuilderReturnType<ValueType>>(m, ("SubsystemBuilderReturnType" + vtSuffix).c_str(),
                                                                           "Result of the construction of a subsystem")
         .def_readonly("model", &storm::transformer::SubsystemBuilderReturnType<ValueType>::model, "the submodel")
         .def_readonly("new_to_old_state_mapping", &storm::transformer::SubsystemBuilderReturnType<ValueType>::newToOldStateIndexMapping,
@@ -87,7 +87,7 @@ void define_transformation_typed(py::module& m, std::string const& vtSuffix) {
                       "If set, deadlock states have been introduced and have been assigned this label");
     m.def(("_construct_subsystem_" + vtSuffix).c_str(), &constructSubsystem<ValueType>, "build a subsystem of a sparse model");
 
-    py::class_<typename storm::transformer::EndComponentEliminator<ValueType>::EndComponentEliminatorReturnType>(
+    py::classh<typename storm::transformer::EndComponentEliminator<ValueType>::EndComponentEliminatorReturnType>(
         m, ("EndComponentEliminatorReturnType" + vtSuffix).c_str(), "Container for result of endcomponent elimination")
         .def_readonly("matrix", &storm::transformer::EndComponentEliminator<ValueType>::EndComponentEliminatorReturnType::matrix, "The resulting matrix")
         .def_readonly("new_to_old_row_mapping", &storm::transformer::EndComponentEliminator<ValueType>::EndComponentEliminatorReturnType::newToOldRowMapping,
@@ -103,7 +103,7 @@ void define_transformation_typed(py::module& m, std::string const& vtSuffix) {
 
 template<typename ValueType>
 void define_transformation_typed_only_numbers(py::module& m, std::string const& vtSuffix) {
-    py::class_<storm::transformer::AddUncertainty<ValueType>>(m, ("AddUncertainty" + vtSuffix).c_str(),
+    py::classh<storm::transformer::AddUncertainty<ValueType>>(m, ("AddUncertainty" + vtSuffix).c_str(),
                                                               "Transform model into interval model with specified uncertainty")
         .def(py::init<std::shared_ptr<storm::models::sparse::Model<ValueType>> const&>(), py::arg("model"))
         .def("transform", &storm::transformer::AddUncertainty<ValueType>::transform, "Transform the model", py::arg("additive_uncertainty"),

--- a/src/dft/analysis.cpp
+++ b/src/dft/analysis.cpp
@@ -42,8 +42,7 @@ void define_analysis(py::module& m) {
         .finalize();
 
     // RelevantEvents
-    py::class_<storm::dft::utility::RelevantEvents, std::shared_ptr<storm::dft::utility::RelevantEvents>>(m, "RelevantEvents",
-                                                                                                          "Relevant events which should be observed")
+    py::classh<storm::dft::utility::RelevantEvents>(m, "RelevantEvents", "Relevant events which should be observed")
         .def(py::init<>(), "Create empty list of relevant events")
         .def("is_relevant", &storm::dft::utility::RelevantEvents::isRelevant, "Check whether the given name is a relevant event", py::arg("name"));
 
@@ -53,8 +52,7 @@ void define_analysis(py::module& m) {
 
 template<typename ValueType>
 void define_analysis_typed(py::module& m, std::string const& vt_suffix) {
-    py::class_<ExplicitDFTModelBuilder<ValueType>, std::shared_ptr<ExplicitDFTModelBuilder<ValueType>>>(m, ("ExplicitDFTModelBuilder" + vt_suffix).c_str(),
-                                                                                                        "Builder to generate explicit model from DFT")
+    py::classh<ExplicitDFTModelBuilder<ValueType>>(m, ("ExplicitDFTModelBuilder" + vt_suffix).c_str(), "Builder to generate explicit model from DFT")
         .def(py::init<storm::dft::storage::DFT<ValueType> const&, storm::dft::storage::DftSymmetries const&>(), "Constructor", py::arg("dft"),
              py::arg("symmetries") = storm::dft::storage::DftSymmetries())
         .def("build", &ExplicitDFTModelBuilder<ValueType>::buildModel, "Build state space of model", py::arg("iteration"),

--- a/src/dft/dft.cpp
+++ b/src/dft/dft.cpp
@@ -36,7 +36,7 @@ void define_dft(py::module& m) {
 template<typename ValueType>
 void define_dft_typed(py::module& m, std::string const& vt_suffix) {
     // DFT class
-    py::class_<DFT<ValueType>, std::shared_ptr<DFT<ValueType>>>(m, ("DFT" + vt_suffix).c_str(), "Dynamic Fault Tree")
+    py::classh<DFT<ValueType>>(m, ("DFT" + vt_suffix).c_str(), "Dynamic Fault Tree")
         .def("nr_elements", &DFT<ValueType>::nrElements, "Total number of elements")
         .def("nr_be", &DFT<ValueType>::nrBasicElements, "Number of basic elements")
         .def("nr_dynamic", &DFT<ValueType>::nrDynamicElements, "Number of dynamic elements")
@@ -64,7 +64,7 @@ void define_dft_typed(py::module& m, std::string const& vt_suffix) {
 }
 
 void define_symmetries(py::module& m) {
-    py::class_<storm::dft::storage::DftSymmetries, std::shared_ptr<storm::dft::storage::DftSymmetries>>(m, "DftSymmetries", "Symmetries in DFT")
+    py::classh<storm::dft::storage::DftSymmetries>(m, "DftSymmetries", "Symmetries in DFT")
         .def(py::init<>(), "Constructor for empty symmetry")
         .def("__len__", &storm::dft::storage::DftSymmetries::nrSymmetries)
         .def(

--- a/src/dft/dft_elements.cpp
+++ b/src/dft/dft_elements.cpp
@@ -34,16 +34,15 @@ void define_dft_elements(py::module& m) {
 template<typename ValueType>
 void define_dft_elements_typed(py::module& m, std::string const& vt_suffix) {
     // DFT elements
-    py::class_<DFTElement<ValueType>, std::shared_ptr<DFTElement<ValueType>>> element(m, ("DFTElement" + vt_suffix).c_str(), "DFT element");
+    py::classh<DFTElement<ValueType>> element(m, ("DFTElement" + vt_suffix).c_str(), "DFT element");
     element.def_property_readonly("id", &DFTElement<ValueType>::id, "Id")
         .def_property_readonly("name", &DFTElement<ValueType>::name, "Name")
         .def_property_readonly("type", &DFTElement<ValueType>::type, "Type")
         .def("__str__", &DFTElement<ValueType>::toString);
 
-    py::class_<BE<ValueType>, std::shared_ptr<BE<ValueType>>>(m, ("DFTBE" + vt_suffix).c_str(), "Basic Event", element)
-        .def("__str__", &BE<ValueType>::toString);
+    py::classh<BE<ValueType>>(m, ("DFTBE" + vt_suffix).c_str(), "Basic Event", element).def("__str__", &BE<ValueType>::toString);
 
-    py::class_<Dependency<ValueType>, std::shared_ptr<Dependency<ValueType>>>(m, ("DFTDependency" + vt_suffix).c_str(), "Dependency", element)
+    py::classh<Dependency<ValueType>>(m, ("DFTDependency" + vt_suffix).c_str(), "Dependency", element)
         .def_property_readonly("trigger", &Dependency<ValueType>::triggerEvent, "Trigger event")
         .def_property_readonly("dependent_events", &Dependency<ValueType>::dependentEvents, "Dependent events")
         .def("__str__", &Dependency<ValueType>::toString);

--- a/src/dft/dft_state.cpp
+++ b/src/dft/dft_state.cpp
@@ -14,7 +14,7 @@ typedef storm::dft::storage::FailableElements::const_iterator FailableIter;
 template<typename ValueType>
 void define_dft_state(py::module& m, std::string const& vt_suffix) {
     // DFT state
-    py::class_<DFTState<ValueType>, std::shared_ptr<DFTState<ValueType>>>(m, ("DFTState" + vt_suffix).c_str(), "DFT state")
+    py::classh<DFTState<ValueType>>(m, ("DFTState" + vt_suffix).c_str(), "DFT state")
         .def("operational", &DFTState<ValueType>::isOperational, "Is element operational", py::arg("id"))
         .def(
             "failed", [](DFTState<ValueType> const& state, size_t id) { return state.hasFailed(id); }, "Is element failed", py::arg("id"))
@@ -52,15 +52,15 @@ void define_failable_elements(py::module& m) {
         FailableIter it;
     };
 
-    py::class_<Failable, std::shared_ptr<Failable>>(m, "FailableElements", "Failable elements in DFT state")
+    py::classh<Failable>(m, "FailableElements", "Failable elements in DFT state")
         .def("__iter__", [](py::object s) { return FailableIterator(s.cast<Failable const&>(), s); }, py::keep_alive<0, 1>());
 
-    py::class_<FailableIterator>(m, "FailableIterator")
+    py::classh<FailableIterator>(m, "FailableIterator")
         .def(
             "__iter__", [](FailableIterator& it) -> FailableIterator& { return it; }, py::keep_alive<0, 1>())
         .def("__next__", &FailableIterator::next, py::keep_alive<0, 1>());
 
-    py::class_<FailableIter, std::shared_ptr<FailableIter>>(m, "FailableElement", "Failable element")
+    py::classh<FailableIter>(m, "FailableElement", "Failable element")
         .def("is_due_dependency", &FailableIter::isFailureDueToDependency, "Is failure due to dependency")
         .def("as_be_double", &FailableIter::asBE<double>, py::arg("dft"), "Get BE which fails")
         .def("as_be_ratfunc", &FailableIter::asBE<storm::RationalFunction>, py::arg("dft"), "Get BE which fails")

--- a/src/dft/module.cpp
+++ b/src/dft/module.cpp
@@ -7,7 +7,7 @@
 using DftIndependentModule = storm::dft::storage::DftIndependentModule;
 
 void define_module(py::module& m) {
-    py::class_<DftIndependentModule, std::shared_ptr<DftIndependentModule>>(m, "DftIndependentModule", "Independent module in DFT")
+    py::classh<DftIndependentModule>(m, "DftIndependentModule", "Independent module in DFT")
         .def("static", &DftIndependentModule::isStatic, "Whether the module contains only static elements (except in submodules)")
         .def("fully_static", &DftIndependentModule::isFullyStatic, "Whether the module contains only static elements (also in submodules)")
         .def("single_be", &DftIndependentModule::isSingleBE, "Whether the module consists of a single BE (trivial module)")

--- a/src/dft/simulator.cpp
+++ b/src/dft/simulator.cpp
@@ -24,9 +24,9 @@ void define_simulator(py::module& m) {
         .value("INVALID", storm::dft::simulator::SimulationTraceResult::INVALID)
         .value("CONTINUE", storm::dft::simulator::SimulationTraceResult::CONTINUE)
         .finalize();
-    py::class_<DFTStateInfo, std::shared_ptr<DFTStateInfo>>(m, "DFTStateInfo", "State Generation Info for DFT");
+    py::classh<DFTStateInfo>(m, "DFTStateInfo", "State Generation Info for DFT");
 
-    py::class_<RandomGenerator, std::shared_ptr<RandomGenerator>>(m, "RandomGenerator", "Random number generator")
+    py::classh<RandomGenerator>(m, "RandomGenerator", "Random number generator")
         .def_static(
             "create", [](unsigned int seed) -> RandomGenerator { return RandomGenerator(seed); }, py::arg("seed"), "Initialize random number generator");
 }
@@ -34,7 +34,7 @@ void define_simulator(py::module& m) {
 template<typename ValueType>
 void define_simulator_typed(py::module& m, std::string const& vt_suffix) {
     // Simulator for DFTs
-    py::class_<Simulator<ValueType>, std::shared_ptr<Simulator<ValueType>>>(m, ("DFTSimulator" + vt_suffix).c_str(), "Simulator for DFT traces")
+    py::classh<Simulator<ValueType>>(m, ("DFTSimulator" + vt_suffix).c_str(), "Simulator for DFT traces")
         .def(py::init<storm::dft::storage::DFT<ValueType> const&, DFTStateInfo const&, RandomGenerator&>(), py::keep_alive<1, 2>(), py::keep_alive<1, 3>(),
              py::keep_alive<1, 4>(), py::arg("dft"), py::arg("state_generation_info"), py::arg("generator"), "Create Simulator")
         .def("reset", &Simulator<ValueType>::resetToInitial, "Reset to initial state")

--- a/src/dft/transformations.cpp
+++ b/src/dft/transformations.cpp
@@ -8,7 +8,7 @@
 using DFTInstantiator = storm::dft::transformations::DftInstantiator<storm::RationalFunction, double>;
 
 void define_transformations(py::module& m) {
-    py::class_<DFTInstantiator, std::shared_ptr<DFTInstantiator>>(m, "DFTInstantiator", "Instantiator for parametric DFT")
+    py::classh<DFTInstantiator>(m, "DFTInstantiator", "Instantiator for parametric DFT")
         .def(py::init<storm::dft::storage::DFT<storm::RationalFunction> const&>(), "Initialize with parametric DFT", py::arg("dft"))
         .def("instantiate", &DFTInstantiator::instantiate, "Instantiate parametric DFT and obtain concrete DFT", py::arg("valuation"));
 }

--- a/src/gspn/gspn.cpp
+++ b/src/gspn/gspn.cpp
@@ -30,7 +30,7 @@ void gspnToFile(GSPN const& gspn, std::string const& filepath, bool toPnpro) {
 
 void define_gspn(py::module& m) {
     // GSPN_Builder class
-    py::class_<GSPNBuilder, std::shared_ptr<GSPNBuilder>>(m, "GSPNBuilder", "Generalized Stochastic Petri Net Builder")
+    py::classh<GSPNBuilder>(m, "GSPNBuilder", "Generalized Stochastic Petri Net Builder")
         .def(py::init(), "Constructor")
         .def("set_name", &GSPNBuilder::setGspnName, "Set name of GSPN", "name"_a)
 
@@ -106,7 +106,7 @@ void define_gspn(py::module& m) {
              "constants_substitution"_a = std::map<storm::expressions::Variable, storm::expressions::Expression>());
 
     // GSPN class
-    py::class_<GSPN, std::shared_ptr<GSPN>>(m, "GSPN", "Generalized Stochastic Petri Net")
+    py::classh<GSPN>(m, "GSPN", "Generalized Stochastic Petri Net")
         // Constructor
         .def(py::init<std::string const&, std::vector<Place> const&, std::vector<ImmediateTransition> const&, std::vector<TimedTransition> const&,
                       std::vector<TransitionPartition> const&, std::shared_ptr<storm::expressions::ExpressionManager> const&,
@@ -174,7 +174,7 @@ void define_gspn(py::module& m) {
         .def_static("transition_id_to_immediate_transition_id", &GSPN::transitionIdToImmediateTransitionId);
 
     // LayoutInfo class
-    py::class_<LayoutInfo>(m, "LayoutInfo")
+    py::classh<LayoutInfo>(m, "LayoutInfo")
         .def(py::init<>())
         .def(py::init<double, double, double>(), "x"_a, "y"_a, "rotation"_a = 0.0)
         .def_readwrite("x", &LayoutInfo::x)
@@ -182,7 +182,7 @@ void define_gspn(py::module& m) {
         .def_readwrite("rotation", &LayoutInfo::rotation);
 
     // Place class
-    py::class_<Place, std::shared_ptr<Place>>(m, "Place", "Place in a GSPN")
+    py::classh<Place>(m, "Place", "Place in a GSPN")
         .def(py::init<uint64_t>(), "id"_a)
         .def("get_name", &Place::getName, "Get name of this place")
         .def("set_name", &Place::setName, "name"_a, "Set name of this place")
@@ -194,7 +194,7 @@ void define_gspn(py::module& m) {
         .def("has_restricted_capacity", &Place::hasRestrictedCapacity, "Is capacity of this place restricted");
 
     // Transition class
-    py::class_<Transition, std::shared_ptr<Transition>>(m, "Transition", "Transition in a GSPN")
+    py::classh<Transition>(m, "Transition", "Transition in a GSPN")
         .def(py::init<>())
         .def("get_id", &Transition::getID, "Get id of this transition")
         .def("set_name", &Transition::setName, "name"_a, "Set name of this transition")
@@ -232,7 +232,7 @@ void define_gspn(py::module& m) {
         ;
 
     // TimedTransition class
-    py::class_<TimedTransition, Transition, std::shared_ptr<TimedTransition>>(m, "TimedTransition", "TimedTransition in a GSPN")
+    py::classh<TimedTransition, Transition>(m, "TimedTransition", "TimedTransition in a GSPN")
         .def(py::init<>())
         .def("get_rate", &TimedTransition::getRate, "Get rate of this transition")
         .def("set_rate", &TimedTransition::setRate, "rate"_a, "Set rate of this transition")
@@ -245,14 +245,14 @@ void define_gspn(py::module& m) {
         .def("get_number_of_servers", &TimedTransition::getNumberOfServers, "Get number of servers");
 
     // ImmediateTransition class
-    py::class_<ImmediateTransition, Transition, std::shared_ptr<ImmediateTransition>>(m, "ImmediateTransition", "ImmediateTransition in a GSPN")
+    py::classh<ImmediateTransition, Transition>(m, "ImmediateTransition", "ImmediateTransition in a GSPN")
         .def(py::init<>())
         .def("get_weight", &ImmediateTransition::getWeight, "Get weight of this transition")
         .def("set_weight", &ImmediateTransition::setWeight, "weight"_a, "Set weight of this transition")
         .def("no_weight_attached", &ImmediateTransition::noWeightAttached, "True iff no weight is attached");
 
     // TransitionPartition class
-    py::class_<TransitionPartition>(m, "TransitionPartition")
+    py::classh<TransitionPartition>(m, "TransitionPartition")
         .def(py::init<>())
         .def_readwrite("priority", &TransitionPartition::priority)
         .def_readwrite("transitions", &TransitionPartition::transitions)

--- a/src/gspn/gspn_io.cpp
+++ b/src/gspn/gspn_io.cpp
@@ -11,7 +11,7 @@ using GSPNJaniBuilder = storm::builder::JaniGSPNBuilder;
 
 void define_gspn_io(py::module& m) {
     // GspnParser class
-    py::class_<GSPNParser, std::shared_ptr<GSPNParser>>(m, "GSPNParser")
+    py::classh<GSPNParser>(m, "GSPNParser")
         .def(py::init<>())
         .def(
             "parse",
@@ -21,7 +21,7 @@ void define_gspn_io(py::module& m) {
             "filename"_a, "constant_definitions"_a = "");
 
     // GspnToJani builder
-    py::class_<GSPNJaniBuilder, std::shared_ptr<GSPNJaniBuilder>>(m, "GSPNToJaniBuilder")
+    py::classh<GSPNJaniBuilder>(m, "GSPNToJaniBuilder")
         .def(py::init<GSPN const&>(), py::arg("gspn"))
         .def("build", &GSPNJaniBuilder::build, py::arg("automaton_name") = "gspn_automaton", "Build Jani model from GSPN")
         .def("create_deadlock_properties", &GSPNJaniBuilder::getDeadlockProperties, py::arg("jani_model"), "Create standard properties for deadlocks");

--- a/src/logic/formulae.cpp
+++ b/src/logic/formulae.cpp
@@ -19,7 +19,7 @@ void define_formulae(py::module& m) {
         .value("OR", storm::logic::BinaryBooleanOperatorType::Or)
         .finalize();
 
-    py::class_<storm::logic::Formula, std::shared_ptr<storm::logic::Formula>> formula(m, "Formula", "Generic Storm Formula");
+    py::classh<storm::logic::Formula> formula(m, "Formula", "Generic Storm Formula");
     formula.def("__str__", &storm::logic::Formula::toString)
         .def("clone",
              [](storm::logic::Formula const& f) {
@@ -45,21 +45,16 @@ void define_formulae(py::module& m) {
         .def_property_readonly("is_multi_objective_formula", &storm::logic::Formula::isMultiObjectiveFormula);
 
     // Path Formulae
-    py::class_<storm::logic::PathFormula, std::shared_ptr<storm::logic::PathFormula>> pathFormula(
-        m, "PathFormula", "Formula about the probability of a set of paths in an automaton", formula);
-    py::class_<storm::logic::UnaryPathFormula, std::shared_ptr<storm::logic::UnaryPathFormula>> unaryPathFormula(m, "UnaryPathFormula",
-                                                                                                                 "Path formula with one operand", pathFormula);
+    py::classh<storm::logic::PathFormula> pathFormula(m, "PathFormula", "Formula about the probability of a set of paths in an automaton", formula);
+    py::classh<storm::logic::UnaryPathFormula> unaryPathFormula(m, "UnaryPathFormula", "Path formula with one operand", pathFormula);
     unaryPathFormula.def_property_readonly("subformula", &storm::logic::UnaryPathFormula::getSubformula, "the subformula");
-    py::class_<storm::logic::EventuallyFormula, std::shared_ptr<storm::logic::EventuallyFormula>>(m, "EventuallyFormula", "Formula for eventually",
-                                                                                                  unaryPathFormula)
+    py::classh<storm::logic::EventuallyFormula>(m, "EventuallyFormula", "Formula for eventually", unaryPathFormula)
         .def_property_readonly("subformula", &storm::logic::EventuallyFormula::getSubformula, "the subformula");
-    py::class_<storm::logic::GloballyFormula, std::shared_ptr<storm::logic::GloballyFormula>>(m, "GloballyFormula", "Formula for globally", unaryPathFormula);
-    py::class_<storm::logic::BinaryPathFormula, std::shared_ptr<storm::logic::BinaryPathFormula>> binaryPathFormula(
-        m, "BinaryPathFormula", "Path formula with two operands", pathFormula);
+    py::classh<storm::logic::GloballyFormula>(m, "GloballyFormula", "Formula for globally", unaryPathFormula);
+    py::classh<storm::logic::BinaryPathFormula> binaryPathFormula(m, "BinaryPathFormula", "Path formula with two operands", pathFormula);
     binaryPathFormula.def_property_readonly("left_subformula", &storm::logic::BinaryPathFormula::getLeftSubformula);
     binaryPathFormula.def_property_readonly("right_subformula", &storm::logic::BinaryPathFormula::getRightSubformula);
-    py::class_<storm::logic::BoundedUntilFormula, std::shared_ptr<storm::logic::BoundedUntilFormula>>(
-        m, "BoundedUntilFormula", "Until Formula with either a step or a time bound.", binaryPathFormula)
+    py::classh<storm::logic::BoundedUntilFormula>(m, "BoundedUntilFormula", "Until Formula with either a step or a time bound.", binaryPathFormula)
         .def_property_readonly("is_multidimensional", &storm::logic::BoundedUntilFormula::isMultiDimensional, "Is the bound multi-dimensional")
         .def_property_readonly("has_lower_bound", [](storm::logic::BoundedUntilFormula const& form) { return form.hasLowerBound(); })
         .def_property_readonly("upper_bound_expression", [](storm::logic::BoundedUntilFormula const& form) { return form.getUpperBound(); })
@@ -69,44 +64,32 @@ void define_formulae(py::module& m) {
         .def_property_readonly(
             "right_subformula", [](storm::logic::BoundedUntilFormula const& form) -> storm::logic::Formula const& { return form.getRightSubformula(); },
             py::return_value_policy::reference_internal);
-    py::class_<storm::logic::ConditionalFormula, std::shared_ptr<storm::logic::ConditionalFormula>>(
-        m, "ConditionalFormula", "Formula with the right hand side being a condition.", formula)
+    py::classh<storm::logic::ConditionalFormula>(m, "ConditionalFormula", "Formula with the right hand side being a condition.", formula)
         .def_property_readonly("main_subformula", &storm::logic::ConditionalFormula::getSubformula, "the subformula")
         .def_property_readonly("conditional_subformula", &storm::logic::ConditionalFormula::getConditionFormula, "the conditional subformula");
-    py::class_<storm::logic::UntilFormula, std::shared_ptr<storm::logic::UntilFormula>>(m, "UntilFormula", "Path Formula for unbounded until",
-                                                                                        binaryPathFormula);
+    py::classh<storm::logic::UntilFormula>(m, "UntilFormula", "Path Formula for unbounded until", binaryPathFormula);
 
     // Reward Path Formulae
     // py::class_<storm::logic::RewardPathFormula, std::shared_ptr<storm::logic::RewardPathFormula>(m, "RewardPathFormula", "Formula about the rewards of a set
     // of paths in an automaton", py::base<storm::logic::Formula>());
-    py::class_<storm::logic::CumulativeRewardFormula, std::shared_ptr<storm::logic::CumulativeRewardFormula>>(m, "CumulativeRewardFormula",
-                                                                                                              "Summed rewards over a the paths", pathFormula);
-    py::class_<storm::logic::InstantaneousRewardFormula, std::shared_ptr<storm::logic::InstantaneousRewardFormula>>(m, "InstantaneousRewardFormula",
-                                                                                                                    "Instantaneous reward", pathFormula);
-    py::class_<storm::logic::LongRunAverageRewardFormula, std::shared_ptr<storm::logic::LongRunAverageRewardFormula>>(m, "LongRunAverageRewardFormula",
-                                                                                                                      "Long run average reward", pathFormula);
+    py::classh<storm::logic::CumulativeRewardFormula>(m, "CumulativeRewardFormula", "Summed rewards over a the paths", pathFormula);
+    py::classh<storm::logic::InstantaneousRewardFormula>(m, "InstantaneousRewardFormula", "Instantaneous reward", pathFormula);
+    py::classh<storm::logic::LongRunAverageRewardFormula>(m, "LongRunAverageRewardFormula", "Long run average reward", pathFormula);
     // py::class_<storm::logic::ReachabilityRewardFormula, std::shared_ptr<storm::logic::ReachabilityRewardFormula>>(m, "ReachabilityRewardFormula",
     // "Reachability reward", py::base<storm::logic::RewardPathFormula>());
 
     // State Formulae
-    py::class_<storm::logic::StateFormula, std::shared_ptr<storm::logic::StateFormula>> stateFormula(m, "StateFormula", "Formula about a state of an automaton",
-                                                                                                     formula);
-    py::class_<storm::logic::AtomicExpressionFormula, std::shared_ptr<storm::logic::AtomicExpressionFormula>>(m, "AtomicExpressionFormula",
-                                                                                                              "Formula with an atomic expression", stateFormula)
+    py::classh<storm::logic::StateFormula> stateFormula(m, "StateFormula", "Formula about a state of an automaton", formula);
+    py::classh<storm::logic::AtomicExpressionFormula>(m, "AtomicExpressionFormula", "Formula with an atomic expression", stateFormula)
         .def("get_expression", &storm::logic::AtomicExpressionFormula::getExpression);
-    py::class_<storm::logic::AtomicLabelFormula, std::shared_ptr<storm::logic::AtomicLabelFormula>>(m, "AtomicLabelFormula", "Formula with an atomic label",
-                                                                                                    stateFormula)
+    py::classh<storm::logic::AtomicLabelFormula>(m, "AtomicLabelFormula", "Formula with an atomic label", stateFormula)
         .def_property_readonly("label", &storm::logic::AtomicLabelFormula::getLabel, "label in the formula");
-    py::class_<storm::logic::BooleanLiteralFormula, std::shared_ptr<storm::logic::BooleanLiteralFormula>>(m, "BooleanLiteralFormula",
-                                                                                                          "Formula with a boolean literal", stateFormula)
+    py::classh<storm::logic::BooleanLiteralFormula>(m, "BooleanLiteralFormula", "Formula with a boolean literal", stateFormula)
         .def(py::init<bool>(), "truth value"_a);
-    py::class_<storm::logic::UnaryStateFormula, std::shared_ptr<storm::logic::UnaryStateFormula>> unaryStateFormula(
-        m, "UnaryStateFormula", "State formula with one operand", stateFormula);
+    py::classh<storm::logic::UnaryStateFormula> unaryStateFormula(m, "UnaryStateFormula", "State formula with one operand", stateFormula);
     unaryStateFormula.def_property_readonly("subformula", &storm::logic::UnaryStateFormula::getSubformula, "the subformula");
-    py::class_<storm::logic::UnaryBooleanStateFormula, std::shared_ptr<storm::logic::UnaryBooleanStateFormula>>(
-        m, "UnaryBooleanStateFormula", "Unary boolean state formula", unaryStateFormula);
-    py::class_<storm::logic::OperatorFormula, std::shared_ptr<storm::logic::OperatorFormula>> operatorFormula(m, "OperatorFormula", "Operator formula",
-                                                                                                              unaryStateFormula);
+    py::classh<storm::logic::UnaryBooleanStateFormula>(m, "UnaryBooleanStateFormula", "Unary boolean state formula", unaryStateFormula);
+    py::classh<storm::logic::OperatorFormula> operatorFormula(m, "OperatorFormula", "Operator formula", unaryStateFormula);
     operatorFormula.def_property_readonly("has_bound", &storm::logic::OperatorFormula::hasBound, "Flag if formula is bounded")
         .def_property("comparison_type", &storm::logic::OperatorFormula::getComparisonType, &storm::logic::OperatorFormula::setComparisonType,
                       "Comparison type of bound")
@@ -140,27 +123,21 @@ void define_formulae(py::module& m) {
         .def("remove_optimality_type", &storm::logic::OperatorFormula::removeOptimalityType, "remove the optimality type")
 
         ;
-    py::class_<storm::logic::TimeOperatorFormula, std::shared_ptr<storm::logic::TimeOperatorFormula>>(m, "TimeOperator", "The time operator", operatorFormula);
-    py::class_<storm::logic::LongRunAverageOperatorFormula, std::shared_ptr<storm::logic::LongRunAverageOperatorFormula>>(
-        m, "LongRunAvarageOperator", "Long run average operator", operatorFormula);
-    py::class_<storm::logic::ProbabilityOperatorFormula, std::shared_ptr<storm::logic::ProbabilityOperatorFormula>>(m, "ProbabilityOperator",
-                                                                                                                    "Probability operator", operatorFormula)
+    py::classh<storm::logic::TimeOperatorFormula>(m, "TimeOperator", "The time operator", operatorFormula);
+    py::classh<storm::logic::LongRunAverageOperatorFormula>(m, "LongRunAvarageOperator", "Long run average operator", operatorFormula);
+    py::classh<storm::logic::ProbabilityOperatorFormula>(m, "ProbabilityOperator", "Probability operator", operatorFormula)
         .def(py::init<std::shared_ptr<storm::logic::Formula>>(), "construct probability operator formula", py::arg("subformula"));
 
-    py::class_<storm::logic::RewardOperatorFormula, std::shared_ptr<storm::logic::RewardOperatorFormula>>(m, "RewardOperator", "Reward operator",
-                                                                                                          operatorFormula)
+    py::classh<storm::logic::RewardOperatorFormula>(m, "RewardOperator", "Reward operator", operatorFormula)
         .def("has_reward_name", &storm::logic::RewardOperatorFormula::hasRewardModelName)
         .def_property_readonly("reward_name", &storm::logic::RewardOperatorFormula::getRewardModelName);
-    py::class_<storm::logic::BinaryStateFormula, std::shared_ptr<storm::logic::BinaryStateFormula>> binaryStateFormula(
-        m, "BinaryStateFormula", "State formula with two operands", stateFormula);
-    py::class_<storm::logic::BinaryBooleanStateFormula, std::shared_ptr<storm::logic::BinaryBooleanStateFormula>>(
-        m, "BooleanBinaryStateFormula", "Boolean binary state formula", binaryStateFormula);
+    py::classh<storm::logic::BinaryStateFormula> binaryStateFormula(m, "BinaryStateFormula", "State formula with two operands", stateFormula);
+    py::classh<storm::logic::BinaryBooleanStateFormula>(m, "BooleanBinaryStateFormula", "Boolean binary state formula", binaryStateFormula);
 
-    py::class_<storm::logic::MultiObjectiveFormula, std::shared_ptr<storm::logic::MultiObjectiveFormula>>(m, "MultiObjectiveFormula", "Multi objective formula",
-                                                                                                          formula)
+    py::classh<storm::logic::MultiObjectiveFormula>(m, "MultiObjectiveFormula", "Multi objective formula", formula)
         .def_property_readonly("subformulas", &storm::logic::MultiObjectiveFormula::getSubformulas, "Get vector of subformulas")
         .def_property_readonly("nr_subformulas", &storm::logic::MultiObjectiveFormula::getNumberOfSubformulas, "Get number of subformulas");
 
-    py::class_<storm::logic::GameFormula, std::shared_ptr<storm::logic::GameFormula>>(m, "GameFormula", "Game formula", unaryStateFormula)
+    py::classh<storm::logic::GameFormula>(m, "GameFormula", "Game formula", unaryStateFormula)
         .def_property_readonly("is_game_formula", &storm::logic::GameFormula::isGameFormula, "is it a game formula");
 }

--- a/src/mod_info.cpp
+++ b/src/mod_info.cpp
@@ -10,7 +10,7 @@ PYBIND11_MODULE(_info, m) {
     options.disable_function_signatures();
 #endif
 
-    py::class_<storm::StormVersion>(m, "Version", "Version information for Storm")
+    py::classh<storm::StormVersion>(m, "Version", "Version information for Storm")
         // static properties are still called with self as argument (which we ignore), see
         // https://pybind11.readthedocs.io/en/stable/advanced/classes.html#static-properties
         .def_property_readonly_static(

--- a/src/pars/model_instantiator.cpp
+++ b/src/pars/model_instantiator.cpp
@@ -34,7 +34,7 @@ using namespace storm::modelchecker;
 // Helper: define typed ModelInstantiator class
 template<typename ParametricModel, typename InstantiatedModel>
 void define_typed_instantiator(py::module& m, const char* pyName, const char* pyDesc) {
-    py::class_<storm::utility::ModelInstantiator<ParametricModel, InstantiatedModel>>(m, pyName, pyDesc)
+    py::classh<storm::utility::ModelInstantiator<ParametricModel, InstantiatedModel>>(m, pyName, pyDesc)
         .def(py::init<ParametricModel>(), "parametric model"_a)
         .def("instantiate", &storm::utility::ModelInstantiator<ParametricModel, InstantiatedModel>::instantiate,
              "Instantiate model with given parameter values");
@@ -80,10 +80,10 @@ template<typename ModelType, typename ResultType>
 void define_typed_checker(py::module& m, const char* baseName, const char* baseDesc, const char* derivedName, const char* derivedDesc) {
     using CheckerType = typename instantiation_checker<ModelType, ResultType>::type;
     using BaseChecker = SparseInstantiationModelChecker<ModelType, ResultType>;
-    auto base = py::class_<BaseChecker, std::shared_ptr<BaseChecker>>(m, baseName, baseDesc);
+    auto base = py::classh<BaseChecker>(m, baseName, baseDesc);
     base.def("specify_formula", &BaseChecker::specifyFormula, "check_task"_a);
 
-    py::class_<CheckerType, std::shared_ptr<CheckerType>>(m, derivedName, derivedDesc, base)
+    py::classh<CheckerType>(m, derivedName, derivedDesc, base)
         .def(py::init<ModelType>(), "parametric model"_a)
         .def(
             "check",

--- a/src/pars/pars.cpp
+++ b/src/pars/pars.cpp
@@ -20,8 +20,7 @@ void define_pars(py::module& m) {
         },
         "Initialize Storm-pars");
 
-    py::class_<SparseParametricDtmcSimplifier, std::shared_ptr<SparseParametricDtmcSimplifier>>(m, "_SparseParametricDtmcSimplifier",
-                                                                                                "Model simplifier for parametric DTMCs")
+    py::classh<SparseParametricDtmcSimplifier>(m, "_SparseParametricDtmcSimplifier", "Model simplifier for parametric DTMCs")
         .def(py::init<Dtmc const&>(), py::arg("dtmc"))
         .def(
             "simplify", [](SparseParametricDtmcSimplifier& simplifier, storm::logic::Formula const& formula) -> bool { return simplifier.simplify(formula); },
@@ -32,8 +31,7 @@ void define_pars(py::module& m) {
             "simplified_formula", [](SparseParametricDtmcSimplifier const& simplifier) { return simplifier.getSimplifiedFormula(); },
             "Return simplified formula");
 
-    py::class_<SparseParametricMdpSimplifier, std::shared_ptr<SparseParametricMdpSimplifier>>(m, "_SparseParametricMdpSimplifier",
-                                                                                              "Model simplifier for parametric MDPs")
+    py::classh<SparseParametricMdpSimplifier>(m, "_SparseParametricMdpSimplifier", "Model simplifier for parametric MDPs")
         .def(py::init<Mdp const&>(), py::arg("mdp"))
         .def(
             "simplify", [](SparseParametricMdpSimplifier& simplifier, storm::logic::Formula const& formula) -> bool { return simplifier.simplify(formula); },

--- a/src/pars/pla.cpp
+++ b/src/pars/pla.cpp
@@ -120,7 +120,7 @@ void define_pla(py::module& m) {
                                                                               py::name("friendly_name"), py::is_method(m.attr("RegionResultHypothesis")));
 
     // Region
-    py::class_<Region, std::shared_ptr<Region>>(m, "ParameterRegion", "Parameter region")
+    py::classh<Region>(m, "ParameterRegion", "Parameter region")
         .def(py::init([](std::map<Region::VariableType, std::pair<Region::CoefficientType, Region::CoefficientType>> valuation) {
                  Region::Valuation lowerValuation;
                  Region::Valuation upperValuation;
@@ -141,8 +141,7 @@ void define_pla(py::module& m) {
         .def("__str__", &streamToString<Region>);
 
     // RegionModelChecker
-    py::class_<RegionModelChecker, std::shared_ptr<RegionModelChecker>> regionModelChecker(m, "RegionModelChecker",
-                                                                                           "Region model checker via paramater lifting");
+    py::classh<RegionModelChecker> regionModelChecker(m, "RegionModelChecker", "Region model checker via paramater lifting");
     regionModelChecker
         .def("check_region", &checkRegion, "Check region", py::arg("environment"), py::arg("region"),
              py::arg("hypothesis") = storm::modelchecker::RegionResultHypothesis::Unknown, py::arg("sampleVertices") = false)
@@ -152,7 +151,7 @@ void define_pla(py::module& m) {
              py::arg("splitting_estimate") = std::nullopt, py::arg("allow_model_simplification") = true, py::arg("graph_preserving") = true);
 
     // RegionRefinementChecker
-    py::class_<RegionRefinementChecker, std::shared_ptr<RegionRefinementChecker>>(m, "RegionRefinementChecker", "Region refinement checker")
+    py::classh<RegionRefinementChecker>(m, "RegionRefinementChecker", "Region refinement checker")
         .def("specify", &specifyRefinementChecker, "specify arguments", py::arg("environment"), py::arg("model"), py::arg("formula"),
              py::arg("allow_model_simplification") = true, py::arg("graph_preserving") = true)
         .def(
@@ -165,12 +164,10 @@ void define_pla(py::module& m) {
             "Compute extremum value and point with precision", py::arg("environment"), py::arg("region"), py::arg("extremum_direction"), py::arg("precision"),
             py::arg("precision_absolute") = false);
 
-    py::class_<DtmcParameterLiftingModelChecker, std::shared_ptr<DtmcParameterLiftingModelChecker>>(m, "DtmcParameterLiftingModelChecker",
-                                                                                                    "Region model checker for DTMCs", regionModelChecker)
+    py::classh<DtmcParameterLiftingModelChecker>(m, "DtmcParameterLiftingModelChecker", "Region model checker for DTMCs", regionModelChecker)
         .def(py::init<>())
         .def("get_bound_all_states", &getBound_dtmc, "Get bound", py::arg("environment"), py::arg("region"), py::arg("maximise") = true);
-    py::class_<MdpParameterLiftingModelChecker, std::shared_ptr<MdpParameterLiftingModelChecker>>(m, "MdpParameterLiftingModelChecker",
-                                                                                                  "Region model checker for MPDs", regionModelChecker)
+    py::classh<MdpParameterLiftingModelChecker>(m, "MdpParameterLiftingModelChecker", "Region model checker for MPDs", regionModelChecker)
         .def(py::init<>())
         .def("get_bound_all_states", &getBound_mdp, "Get bound", py::arg("environment"), py::arg("region"), py::arg("maximise") = true);
 

--- a/src/pomdp/generator.cpp
+++ b/src/pomdp/generator.cpp
@@ -19,8 +19,8 @@ using GenerateMonitorVerifierOptions = typename storm::generator::GenerateMonito
 
 template<typename ValueType>
 void define_verimon_generator(py::module &m, std::string const &vtSuffix) {
-    py::class_<storm::generator::MonitorVerifier<ValueType>, std::shared_ptr<storm::generator::MonitorVerifier<ValueType>>> mv(
-        m, ("MonitorVerifier" + vtSuffix).c_str(), "Container for monitor verifier POMDP with associated objects");
+    py::classh<storm::generator::MonitorVerifier<ValueType>> mv(m, ("MonitorVerifier" + vtSuffix).c_str(),
+                                                                "Container for monitor verifier POMDP with associated objects");
     mv.def(py::init<const SparsePomdp<ValueType> &, const std::map<std::pair<uint32_t, bool>, uint32_t> &, const std::map<uint32_t, std::string> &>(),
            py::arg("product"), py::arg("observation_map"), py::arg("default_action_map"));
     mv.def("get_product", &storm::generator::MonitorVerifier<ValueType>::getProduct, py::return_value_policy::reference_internal);
@@ -28,7 +28,7 @@ void define_verimon_generator(py::module &m, std::string const &vtSuffix) {
     mv.def_property_readonly("default_action_map", &storm::generator::MonitorVerifier<ValueType>::getObservationDefaultAction,
                              py::return_value_policy::reference_internal);
 
-    py::class_<storm::generator::GenerateMonitorVerifier<ValueType>> gmv(m, ("GenerateMonitorVerifier" + vtSuffix).c_str(),
+    py::classh<storm::generator::GenerateMonitorVerifier<ValueType>> gmv(m, ("GenerateMonitorVerifier" + vtSuffix).c_str(),
                                                                          "Generator of POMDP used in verifying monitors against markov chains");
     gmv.def(py::init<SparseDtmc<ValueType> const &, SparseMdp<ValueType> const &, std::shared_ptr<storm::expressions::ExpressionManager> &,
                      GenerateMonitorVerifierOptions<ValueType> const &>(),
@@ -36,7 +36,7 @@ void define_verimon_generator(py::module &m, std::string const &vtSuffix) {
     gmv.def("create_product", &storm::generator::GenerateMonitorVerifier<ValueType>::createProduct, "Create the verification POMDP");
     gmv.def("set_risk", &storm::generator::GenerateMonitorVerifier<ValueType>::setRisk, py::arg("risk"));
 
-    py::class_<GenerateMonitorVerifierOptions<ValueType>> gmvopts(m, ("GenerateMonitorVerifier" + vtSuffix + "Options").c_str(),
+    py::classh<GenerateMonitorVerifierOptions<ValueType>> gmvopts(m, ("GenerateMonitorVerifier" + vtSuffix + "Options").c_str(),
                                                                   "Options for corresponding generator");
     gmvopts.def(py::init<>());
     gmvopts.def_readwrite("accepting_label", &GenerateMonitorVerifierOptions<ValueType>::acceptingLabel);

--- a/src/pomdp/memory.cpp
+++ b/src/pomdp/memory.cpp
@@ -5,7 +5,7 @@
 #include "src/helpers.h"
 
 void define_memory(py::module& m) {
-    py::class_<storm::storage::PomdpMemory> memory(m, "PomdpMemory", "Memory for POMDP policies");
+    py::classh<storm::storage::PomdpMemory> memory(m, "PomdpMemory", "Memory for POMDP policies");
     memory.def_property_readonly("nr_states", &storm::storage::PomdpMemory::getNumberOfStates, "How many states does the memory structure have");
 
     // Trivial, FixedCounter, SelectiveCounter, FixedRing, SelectiveRing, SettableBits, Full
@@ -19,7 +19,7 @@ void define_memory(py::module& m) {
         .value("full", storm::storage::PomdpMemoryPattern::Full)
         .finalize();
 
-    py::class_<storm::storage::PomdpMemoryBuilder> memorybuilder(m, "PomdpMemoryBuilder", "MemoryBuilder for POMDP policies");
+    py::classh<storm::storage::PomdpMemoryBuilder> memorybuilder(m, "PomdpMemoryBuilder", "MemoryBuilder for POMDP policies");
     memorybuilder.def(py::init<>());
     memorybuilder.def("build", &storm::storage::PomdpMemoryBuilder::build, py::arg("pattern"), py::arg("nr_states"));
 }

--- a/src/pomdp/qualitative_analysis.cpp
+++ b/src/pomdp/qualitative_analysis.cpp
@@ -41,14 +41,14 @@ void define_qualitative_policy_search(py::module& m, std::string const& vtSuffix
           py::arg("formula"), py::arg("options"));
     m.def(("prepare_pomdp_for_qualitative_search_" + vtSuffix).c_str(), &preparePOMDPForQualitativeSearch<ValueType>, "Preprocess POMDP", py::arg("pomdp"),
           py::arg("formula"));
-    py::class_<storm::pomdp::IterativePolicySearch<ValueType>, std::shared_ptr<storm::pomdp::IterativePolicySearch<ValueType>>> mssq(
-        m, ("IterativeQualitativeSearchSolver" + vtSuffix).c_str(), "Solver for POMDPs that solves qualitative queries");
+    py::classh<storm::pomdp::IterativePolicySearch<ValueType>> mssq(m, ("IterativeQualitativeSearchSolver" + vtSuffix).c_str(),
+                                                                    "Solver for POMDPs that solves qualitative queries");
     mssq.def("compute_winning_region", &storm::pomdp::IterativePolicySearch<ValueType>::computeWinningRegion, py::arg("lookahead"));
     mssq.def("compute_winning_policy_for_initial_states", &storm::pomdp::IterativePolicySearch<ValueType>::analyzeForInitialStates, py::arg("lookahead"));
     mssq.def_property_readonly("last_winning_region", &storm::pomdp::IterativePolicySearch<ValueType>::getLastWinningRegion,
                                "get the last computed winning region");
 
-    py::class_<storm::pomdp::WinningRegionQueryInterface<ValueType>> wrqi(m, ("BeliefSupportWinningRegionQueryInterface" + vtSuffix).c_str());
+    py::classh<storm::pomdp::WinningRegionQueryInterface<ValueType>> wrqi(m, ("BeliefSupportWinningRegionQueryInterface" + vtSuffix).c_str());
     wrqi.def(py::init<SparsePomdp<ValueType> const&, storm::pomdp::WinningRegion const&>(), py::arg("pomdp"), py::arg("BeliefSupportWinningRegion"));
     wrqi.def("query_current_belief", &storm::pomdp::WinningRegionQueryInterface<ValueType>::isInWinningRegion, py::arg("current_belief"));
     wrqi.def("query_action", &storm::pomdp::WinningRegionQueryInterface<ValueType>::staysInWinningRegion, py::arg("current_belief"), py::arg("action"));
@@ -57,10 +57,10 @@ void define_qualitative_policy_search(py::module& m, std::string const& vtSuffix
 template void define_qualitative_policy_search<double>(py::module& m, std::string const& vtSuffix);
 
 void define_qualitative_policy_search_nt(py::module& m) {
-    py::class_<storm::pomdp::MemlessSearchOptions> mssqopts(m, "IterativeQualitativeSearchOptions", "Options for the IterativeQualitativeSearch");
+    py::classh<storm::pomdp::MemlessSearchOptions> mssqopts(m, "IterativeQualitativeSearchOptions", "Options for the IterativeQualitativeSearch");
     mssqopts.def(py::init<>());
 
-    py::class_<storm::pomdp::WinningRegion> winningRegion(m, "BeliefSupportWinningRegion");
+    py::classh<storm::pomdp::WinningRegion> winningRegion(m, "BeliefSupportWinningRegion");
     winningRegion.def_static("load_from_file", &storm::pomdp::WinningRegion::loadFromFile, py::arg("filepath"));
     winningRegion.def("store_to_file", &storm::pomdp::WinningRegion::storeToFile, py::arg("filepath"), py::arg("preamble"), py::arg("append") = false);
 }

--- a/src/pomdp/quantitative_analysis.cpp
+++ b/src/pomdp/quantitative_analysis.cpp
@@ -20,7 +20,7 @@ using additionalCutoffValueType = std::vector<std::vector<std::unordered_map<uin
 
 template<typename ValueType>
 void define_belief_exploration(py::module& m, std::string const& vtSuffix) {
-    py::class_<BeliefExplorationPomdpModelChecker<ValueType>> belmc(m, ("BeliefExplorationModelChecker" + vtSuffix).c_str());
+    py::classh<BeliefExplorationPomdpModelChecker<ValueType>> belmc(m, ("BeliefExplorationModelChecker" + vtSuffix).c_str());
     belmc.def(py::init<std::shared_ptr<Pomdp<ValueType>>, Options<ValueType>>(), py::arg("model"), py::arg("options"));
 
     belmc.def(
@@ -52,10 +52,10 @@ void define_belief_exploration(py::module& m, std::string const& vtSuffix) {
     belmc.def("has_converged", &BeliefExplorationPomdpModelChecker<ValueType>::hasConverged);
     belmc.def("set_fsc_values", &BeliefExplorationPomdpModelChecker<ValueType>::setFMSchedValueList, py::arg("value_list"));
 
-    py::class_<typename storm::builder::BeliefMdpExplorer<Pomdp<ValueType>, ValueType>> belmdpexpl(m, ("BeliefMdpExplorer" + vtSuffix).c_str());
+    py::classh<typename storm::builder::BeliefMdpExplorer<Pomdp<ValueType>, ValueType>> belmdpexpl(m, ("BeliefMdpExplorer" + vtSuffix).c_str());
     belmdpexpl.def("set_fsc_values", &storm::builder::BeliefMdpExplorer<Pomdp<ValueType>, ValueType>::setFMSchedValueList, py::arg("value_list"));
 
-    py::class_<Options<ValueType>> belexploptions(m, ("BeliefExplorationModelCheckerOptions" + vtSuffix).c_str());
+    py::classh<Options<ValueType>> belexploptions(m, ("BeliefExplorationModelCheckerOptions" + vtSuffix).c_str());
     belexploptions.def(py::init<bool, bool>(), py::arg("discretize"), py::arg("unfold"));
     belexploptions.def_readwrite("use_state_elimination_cutoff", &Options<ValueType>::useStateEliminationCutoff);
     belexploptions.def_readwrite("size_threshold_init", &Options<ValueType>::sizeThresholdInit);
@@ -72,7 +72,7 @@ void define_belief_exploration(py::module& m, std::string const& vtSuffix) {
     belexploptions.def_readwrite("interactive_unfolding", &Options<ValueType>::interactiveUnfolding);
     belexploptions.def_readwrite("cut_zero_gap", &Options<ValueType>::cutZeroGap);
 
-    py::class_<typename BeliefExplorationPomdpModelChecker<ValueType>::Result> belexplres(m, ("BeliefExplorationPomdpModelCheckerResult" + vtSuffix).c_str());
+    py::classh<typename BeliefExplorationPomdpModelChecker<ValueType>::Result> belexplres(m, ("BeliefExplorationPomdpModelCheckerResult" + vtSuffix).c_str());
     belexplres.def_readonly("induced_mc_from_scheduler", &BeliefExplorationPomdpModelChecker<ValueType>::Result::schedulerAsMarkovChain);
     belexplres.def_readonly("cutoff_schedulers", &BeliefExplorationPomdpModelChecker<ValueType>::Result::cutoffSchedulers);
     belexplres.def_readonly("lower_bound", &BeliefExplorationPomdpModelChecker<ValueType>::Result::lowerBound);

--- a/src/pomdp/tracker.cpp
+++ b/src/pomdp/tracker.cpp
@@ -16,25 +16,25 @@ using NDPomdpTrackerSparse = storm::generator::NondeterministicBeliefTracker<Val
 
 template<typename ValueType>
 void define_tracker(py::module& m, std::string const& vtSuffix) {
-    py::class_<storm::generator::BeliefSupportTracker<ValueType>> tracker(m, ("BeliefSupportTracker" + vtSuffix).c_str(), "Tracker for BeliefSupports");
+    py::classh<storm::generator::BeliefSupportTracker<ValueType>> tracker(m, ("BeliefSupportTracker" + vtSuffix).c_str(), "Tracker for BeliefSupports");
     tracker.def(py::init<SparsePomdp<ValueType> const&>(), py::arg("pomdp"));
     tracker.def("get_current_belief_support", &SparsePomdpTracker<ValueType>::getCurrentBeliefSupport, "What is the support given the trace so far");
     tracker.def("track", &SparsePomdpTracker<ValueType>::track, py::arg("action"), py::arg("observation"));
 
-    py::class_<storm::generator::SparseBeliefState<ValueType>> sbel(m, ("SparseBeliefState" + vtSuffix).c_str(), "Belief state in sparse format");
+    py::classh<storm::generator::SparseBeliefState<ValueType>> sbel(m, ("SparseBeliefState" + vtSuffix).c_str(), "Belief state in sparse format");
     sbel.def("get", &storm::generator::SparseBeliefState<ValueType>::get, py::arg("state"));
     sbel.def_property_readonly("risk", &storm::generator::SparseBeliefState<ValueType>::getRisk);
     sbel.def("__str__", &storm::generator::SparseBeliefState<ValueType>::toString);
     sbel.def_property_readonly("is_valid", &storm::generator::SparseBeliefState<ValueType>::isValid);
 
-    py::class_<typename NDPomdpTrackerSparse<ValueType>::Options> opts(m, ("NondeterministicBeliefTracker" + vtSuffix + "SparseOptions").c_str(),
+    py::classh<typename NDPomdpTrackerSparse<ValueType>::Options> opts(m, ("NondeterministicBeliefTracker" + vtSuffix + "SparseOptions").c_str(),
                                                                        "Options for the corresponding tracker");
     opts.def(py::init<>());
     opts.def_readwrite("track_timeout", &NDPomdpTrackerSparse<ValueType>::Options::trackTimeOut);
     opts.def_readwrite("reduction_timeout", &NDPomdpTrackerSparse<ValueType>::Options::timeOut);
     opts.def_readwrite("reduction_wiggle", &NDPomdpTrackerSparse<ValueType>::Options::wiggle);
 
-    py::class_<NDPomdpTrackerSparse<ValueType>> ndetbelieftracker(m, ("NondeterministicBeliefTracker" + vtSuffix + "Sparse").c_str(),
+    py::classh<NDPomdpTrackerSparse<ValueType>> ndetbelieftracker(m, ("NondeterministicBeliefTracker" + vtSuffix + "Sparse").c_str(),
                                                                   "Tracker for belief states and uncontrollable actions");
     ndetbelieftracker.def(py::init<SparsePomdp<ValueType> const&, typename NDPomdpTrackerSparse<ValueType>::Options>(), py::arg("pomdp"), py::arg("options"));
     ndetbelieftracker.def("reset", &NDPomdpTrackerSparse<ValueType>::reset);

--- a/src/pomdp/transformations.cpp
+++ b/src/pomdp/transformations.cpp
@@ -55,7 +55,7 @@ void define_transformations_nt(py::module &m) {
         .value("simple_log", storm::transformer::PomdpFscApplicationMode::SIMPLE_LOG)
         .value("full", storm::transformer::PomdpFscApplicationMode::FULL)
         .finalize();
-    py::class_<storm::pomdp::ObservationTraceUnfolderOptions> options(m, "ObservationTraceUnfolderOptions", "Options for unfolding observation traces");
+    py::classh<storm::pomdp::ObservationTraceUnfolderOptions> options(m, "ObservationTraceUnfolderOptions", "Options for unfolding observation traces");
     options.def(py::init<>());
     options.def_readwrite("restart_semantics", &storm::pomdp::ObservationTraceUnfolderOptions::useRestartSemantics,
                           "Use restart semantics instead of a sink state");
@@ -73,7 +73,7 @@ void define_transformations(py::module &m, std::string const &vtSuffix) {
 
 template<typename ValueType>
 void define_transformations_int(py::module &m, std::string const &vtSuffix) {
-    py::class_<storm::pomdp::ObservationTraceUnfolder<ValueType>> unfolder(m, ("ObservationTraceUnfolder" + vtSuffix).c_str(),
+    py::classh<storm::pomdp::ObservationTraceUnfolder<ValueType>> unfolder(m, ("ObservationTraceUnfolder" + vtSuffix).c_str(),
                                                                            "Unfolds observation traces in models");
     unfolder.def(py::init<storm::models::sparse::Pomdp<ValueType>, std::vector<ValueType> const &, std::shared_ptr<storm::expressions::ExpressionManager>,
                           storm::pomdp::ObservationTraceUnfolderOptions const &>(),

--- a/src/pycarl/core/monomial.cpp
+++ b/src/pycarl/core/monomial.cpp
@@ -4,7 +4,7 @@
 #include "src/pycarl/types.h"
 
 void define_monomial(py::module& m) {
-    py::class_<Monomial, std::shared_ptr<Monomial>>(m, "Monomial")
+    py::classh<Monomial>(m, "Monomial")
 
         .def("__pow__", [](const Monomial::Arg& var, carl::uint exp) { return var->pow(exp); })
         .def("__mul__", static_cast<Monomial::Arg (*)(const Monomial::Arg&, const Monomial::Arg&)>(&carl::operator*))

--- a/src/pycarl/core/variable.cpp
+++ b/src/pycarl/core/variable.cpp
@@ -27,7 +27,7 @@ void define_variabletype(py::module& m) {
 }
 
 void define_variable(py::module& m) {
-    py::class_<carl::Variable>(m, "Variable")
+    py::classh<carl::Variable>(m, "Variable")
         .def(py::init<carl::Variable>(), py::arg("other"))
         .def(py::init([](std::string name, carl::VariableType type) { return freshVariable(name, type); }), py::arg("name"),
              py::arg("type") = carl::VariableType::VT_REAL)

--- a/src/pycarl/typed_core/factorization.cpp
+++ b/src/pycarl/typed_core/factorization.cpp
@@ -4,15 +4,14 @@
 #include "src/pycarl/types.h"
 
 void define_factorizationcache(py::module& m) {
-    py::class_<carl::Cache<FactorizationPair>, std::shared_ptr<carl::Cache<FactorizationPair>>>(m, "_FactorizationCache",
-                                                                                                "Cache storing all factorized polynomials")
+    py::classh<carl::Cache<FactorizationPair>>(m, "_FactorizationCache", "Cache storing all factorized polynomials")
         .def(py::init(), "Constructor")
         .def(py::pickle([](const carl::Cache<FactorizationPair>& val) -> std::tuple<std::string> { throw NoPickling(); },
                         [](const std::tuple<std::string>& data) -> std::shared_ptr<carl::Cache<FactorizationPair>> { throw NoPickling(); }));
 }
 
 void define_factorization(py::module& m) {
-    py::class_<Factorization, std::shared_ptr<Factorization>>(m, "Factorization", "Factorization")
+    py::classh<Factorization>(m, "Factorization", "Factorization")
         .def("__str__", &streamToString<Factorization>)
         .def(py::self == py::self)
 

--- a/src/pycarl/typed_core/factorizedpolynomial.cpp
+++ b/src/pycarl/typed_core/factorizedpolynomial.cpp
@@ -4,7 +4,7 @@
 #include "src/pycarl/types.h"
 
 void define_factorizedpolynomial(py::module& m) {
-    py::class_<FactorizedPolynomial>(m, "FactorizedPolynomial", "Represent a polynomial with its factorization")
+    py::classh<FactorizedPolynomial>(m, "FactorizedPolynomial", "Represent a polynomial with its factorization")
         .def(py::init<const Rational&>(), py::arg("number"), "Constructor")
         .def(py::init<const Polynomial&, const std::shared_ptr<carl::Cache<FactorizationPair>>&>(), py::arg("polynomial"), py::arg("cache"), "Constructor")
 

--- a/src/pycarl/typed_core/factorizedrationalfunction.cpp
+++ b/src/pycarl/typed_core/factorizedrationalfunction.cpp
@@ -4,7 +4,7 @@
 #include "src/pycarl/types.h"
 
 void define_factorizedrationalfunction(py::module& m) {
-    py::class_<FactorizedRationalFunction>(m, "FactorizedRationalFunction",
+    py::classh<FactorizedRationalFunction>(m, "FactorizedRationalFunction",
                                            "Represent a rational function, that is the fraction of two factorized polynomials ")
         .def(py::init<FactorizedPolynomial>())
         .def(py::init<FactorizedPolynomial, FactorizedPolynomial>())

--- a/src/pycarl/typed_core/integer.cpp
+++ b/src/pycarl/typed_core/integer.cpp
@@ -9,7 +9,7 @@
 
 void define_cln_integer(py::module& m) {
 #ifdef PYCARL_USE_CLN
-    py::class_<cln::cl_I>(m, "Integer", "Class wrapping cln-integers")
+    py::classh<cln::cl_I>(m, "Integer", "Class wrapping cln-integers")
         .def(py::init<int>())
         .def(py::init([](std::string const& val) {
             cln::cl_I tmp;
@@ -83,7 +83,7 @@ void define_cln_integer(py::module& m) {
 
 void define_gmp_integer(py::module& m) {
 #ifndef PYCARL_USE_CLN
-    py::class_<mpz_class>(m, "Integer", "Class wrapping gmp-integers")
+    py::classh<mpz_class>(m, "Integer", "Class wrapping gmp-integers")
         .def(py::init<int>())
         .def(py::init([](std::string const& val) {
             mpz_class tmp;

--- a/src/pycarl/typed_core/interval.h
+++ b/src/pycarl/typed_core/interval.h
@@ -8,7 +8,7 @@ template<typename Number>
 void define_interval(py::module& m) {
     using Interval = carl::Interval<Number>;
 
-    py::class_<Interval>(m, "Interval")
+    py::classh<Interval>(m, "Interval")
         .def(py::init<const Number&>())
         .def(py::init<const Number&, const Number&>())
         .def(py::init<const Number&, carl::BoundType, const Number&, carl::BoundType>())

--- a/src/pycarl/typed_core/polynomial.cpp
+++ b/src/pycarl/typed_core/polynomial.cpp
@@ -4,7 +4,7 @@
 #include "src/pycarl/types.h"
 
 void define_polynomial(py::module& m) {
-    py::class_<Polynomial>(m, "Polynomial", "Represent a multivariate polynomial")
+    py::classh<Polynomial>(m, "Polynomial", "Represent a multivariate polynomial")
         .def(py::init<const Term&>())
         .def(py::init<const Monomial::Arg&>())
         .def(py::init<carl::Variable::Arg>())

--- a/src/pycarl/typed_core/rational.cpp
+++ b/src/pycarl/typed_core/rational.cpp
@@ -72,7 +72,7 @@ static cln::cl_I pyint_to_cl_I(py::int_ val) {
 
 void define_cln_rational(py::module& m) {
 #ifdef PYCARL_USE_CLN
-    py::class_<cln::cl_RA>(m, "Rational", "Class wrapping cln-rational numbers")
+    py::classh<cln::cl_RA>(m, "Rational", "Class wrapping cln-rational numbers")
         .def(py::init([](double val) { return carl::rationalize<cln::cl_RA>(val); }))
         .def(py::init([](carl::sint val) { return carl::rationalize<cln::cl_RA>(val); }))
         .def(py::init([](const cln::cl_I& numerator, const cln::cl_I& denominator) { return cln::cl_RA(numerator) / cln::cl_RA(denominator); }))
@@ -189,7 +189,7 @@ void define_cln_rational(py::module& m) {
 
 void define_gmp_rational(py::module& m) {
 #ifndef PYCARL_USE_CLN
-    py::class_<mpq_class>(m, "Rational", "Class wrapping gmp-rational numbers")
+    py::classh<mpq_class>(m, "Rational", "Class wrapping gmp-rational numbers")
         .def(py::init([](double val) { return carl::rationalize<mpq_class>(val); }))
         .def(py::init([](carl::sint val) { return carl::rationalize<mpq_class>(val); }))
         .def(py::init<const mpz_class&, const mpz_class&>())

--- a/src/pycarl/typed_core/rationalfunction.cpp
+++ b/src/pycarl/typed_core/rationalfunction.cpp
@@ -4,7 +4,7 @@
 #include "src/pycarl/types.h"
 
 void define_rationalfunction(py::module& m) {
-    py::class_<RationalFunction>(m, "RationalFunction", "Represent a rational function, that is the fraction of two multivariate polynomials ")
+    py::classh<RationalFunction>(m, "RationalFunction", "Represent a rational function, that is the fraction of two multivariate polynomials ")
         .def(py::init<carl::Variable>())
         .def(py::init<Polynomial>())
         .def(py::init<Polynomial, Polynomial>())

--- a/src/pycarl/typed_core/term.cpp
+++ b/src/pycarl/typed_core/term.cpp
@@ -4,7 +4,7 @@
 #include "src/pycarl/types.h"
 
 void define_term(py::module& m) {
-    py::class_<Term>(m, "Term")
+    py::classh<Term>(m, "Term")
         .def(py::init<Rational, const Monomial::Arg&>())
         .def(py::init<carl::Variable&>())
         .def(py::init<Rational const&>())

--- a/src/pycarl/typed_formula/constraint.cpp
+++ b/src/pycarl/typed_formula/constraint.cpp
@@ -4,7 +4,7 @@
 
 //
 void define_constraint(py::module& m) {
-    py::class_<Constraint>(m, "Constraint")
+    py::classh<Constraint>(m, "Constraint")
         .def(py::init<bool>())
         .def(py::init<carl::Variable, carl::Relation, Rational>(), py::arg("var"), py::arg("rel"), py::arg("bound"))
         .def(py::init<Polynomial, carl::Relation>())
@@ -29,7 +29,7 @@ void define_constraint(py::module& m) {
 }
 //
 void define_simple_constraint(py::module& m) {
-    py::class_<SimpleConstraint>(m, "SimpleConstraint")
+    py::classh<SimpleConstraint>(m, "SimpleConstraint")
         .def(py::init<bool>())
         .def(py::init<Polynomial, carl::Relation>())
         .def("__str__", &streamToString<SimpleConstraint>)
@@ -39,7 +39,7 @@ void define_simple_constraint(py::module& m) {
         .def(py::pickle([](const SimpleConstraint& val) -> std::tuple<std::string> { throw NoPickling(); },
                         [](const std::tuple<std::string>& data) -> SimpleConstraint { throw NoPickling(); }));
 
-    py::class_<SimpleConstraintRatFunc>(m, "SimpleConstraintRatFunc")
+    py::classh<SimpleConstraintRatFunc>(m, "SimpleConstraintRatFunc")
         .def(py::init<bool>())
         .def(py::init<FactorizedRationalFunction, carl::Relation>())
         .def("__str__", &streamToString<SimpleConstraintRatFunc>)

--- a/src/pycarl/typed_formula/formula.cpp
+++ b/src/pycarl/typed_formula/formula.cpp
@@ -3,7 +3,7 @@
 #include "src/pycarl/typed_formula/common.h"
 
 void define_formula(py::module& m) {
-    py::class_<Formula>(m, "Formula")
+    py::classh<Formula>(m, "Formula")
         .def(py::init<carl::Variable>(), "Create Formula given Boolean variable")
         .def(py::init<Constraint>())
         .def(py::init<carl::FormulaType, Formula>())

--- a/src/storage/bitvector.cpp
+++ b/src/storage/bitvector.cpp
@@ -7,7 +7,7 @@
 void define_bitvector(py::module& m) {
     using BitVector = storm::storage::BitVector;
 
-    py::class_<BitVector>(m, "BitVector")
+    py::classh<BitVector>(m, "BitVector")
         .def(py::init<>())
         .def(py::init<BitVector>(), "other"_a)
         .def(py::init<uint_fast64_t>(), "length"_a)

--- a/src/storage/choiceorigins.cpp
+++ b/src/storage/choiceorigins.cpp
@@ -10,8 +10,7 @@ using JaniChoiceOrigins = storm::storage::sparse::JaniChoiceOrigins;
 using PrismChoiceOrigins = storm::storage::sparse::PrismChoiceOrigins;
 
 void define_origins(py::module& m) {
-    py::class_<ChoiceOrigins, std::shared_ptr<ChoiceOrigins>> co(m, "ChoiceOrigins",
-                                                                 "This class represents the origin of choices of a model in terms of the input model spec.");
+    py::classh<ChoiceOrigins> co(m, "ChoiceOrigins", "This class represents the origin of choices of a model in terms of the input model spec.");
     co.def("is_prism_choice_origins", &ChoiceOrigins::isPrismChoiceOrigins)
         .def("is_jani_choice_origins", &ChoiceOrigins::isJaniChoiceOrigins)
         .def("as_prism_choice_origins", [](ChoiceOrigins& co) -> PrismChoiceOrigins& { return co.asPrismChoiceOrigins(); })
@@ -20,8 +19,7 @@ void define_origins(py::module& m) {
         .def("get_choice_info", &ChoiceOrigins::getChoiceInfo, "identifier"_a, "human readable string")
         .def("get_number_of_identifiers", &ChoiceOrigins::getNumberOfIdentifiers, "the number of considered identifier");
 
-    py::class_<JaniChoiceOrigins, std::shared_ptr<JaniChoiceOrigins>>(m, "JaniChoiceOrigins",
-                                                                      "This class represents for each choice the origin in the jani spec.", co)
+    py::classh<JaniChoiceOrigins>(m, "JaniChoiceOrigins", "This class represents for each choice the origin in the jani spec.", co)
         .def(py::init<std::shared_ptr<storm::jani::Model const> const&, std::vector<uint_fast64_t> const&,
                       std::vector<JaniChoiceOrigins::EdgeIndexSet> const&>(),
              "jani_model"_a, "index_to_identifier_mapping"_a, "identifier_to_edge_index__set_mapping"_a)
@@ -30,8 +28,7 @@ void define_origins(py::module& m) {
             "get_edge_index_set", [](JaniChoiceOrigins const& co, uint64_t choice) -> auto& { return co.getEdgeIndexSet(choice); },
             "returns the set of edges that induced the choice", py::arg("choice_index"));
 
-    py::class_<PrismChoiceOrigins, std::shared_ptr<PrismChoiceOrigins>>(
-        m, "PrismChoiceOrigins", "This class represents for each choice the set of prism commands that induced the choice.", co)
+    py::classh<PrismChoiceOrigins>(m, "PrismChoiceOrigins", "This class represents for each choice the set of prism commands that induced the choice.", co)
         .def(py::init<std::shared_ptr<storm::prism::Program const> const&, std::vector<uint_fast64_t> const&,
                       std::vector<PrismChoiceOrigins::CommandSet> const&>(),
              "prism_program"_a, "index_to_identifier_mapping"_a, "identifier_to_command_set_mapping"_a)

--- a/src/storage/dd.cpp
+++ b/src/storage/dd.cpp
@@ -9,38 +9,38 @@
 #include "src/helpers.h"
 
 template<storm::dd::DdType DdType>
-py::class_<storm::dd::Dd<DdType>> define_dd(py::module& m, std::string const& libstring) {
-    py::class_<storm::dd::DdMetaVariable<DdType>> ddMetaVariable(m, (std::string("DdMetaVariable_") + libstring).c_str());
+py::classh<storm::dd::Dd<DdType>> define_dd(py::module& m, std::string const& libstring) {
+    py::classh<storm::dd::DdMetaVariable<DdType>> ddMetaVariable(m, (std::string("DdMetaVariable_") + libstring).c_str());
     ddMetaVariable.def("compute_indices", &storm::dd::DdMetaVariable<DdType>::getIndices, py::arg("sorted") = true);
     ddMetaVariable.def_property_readonly("name", &storm::dd::DdMetaVariable<DdType>::getName);
     ddMetaVariable.def_property_readonly("lowest_value", &storm::dd::DdMetaVariable<DdType>::getLow);
     ddMetaVariable.def_property_readonly("type", &storm::dd::DdMetaVariable<DdType>::getType);
     ddMetaVariable.def("__str__", &storm::dd::DdMetaVariable<DdType>::getName);
 
-    py::class_<storm::dd::DdManager<DdType>, std::shared_ptr<storm::dd::DdManager<DdType>>> ddManager(m, (std::string("DdManager_") + libstring).c_str());
+    py::classh<storm::dd::DdManager<DdType>> ddManager(m, (std::string("DdManager_") + libstring).c_str());
     ddManager.def(
         "get_meta_variable", [](storm::dd::DdManager<DdType> const& manager, storm::expressions::Variable const& var) { return manager.getMetaVariable(var); },
         py::arg("expression_variable"));
 
-    py::class_<storm::dd::Dd<DdType>> dd(m, (std::string("Dd_") + libstring).c_str(), "Dd");
+    py::classh<storm::dd::Dd<DdType>> dd(m, (std::string("Dd_") + libstring).c_str(), "Dd");
     dd.def_property_readonly("node_count", &storm::dd::Dd<DdType>::getNodeCount, "get node count");
     dd.def_property_readonly("dd_manager", &storm::dd::Dd<DdType>::getDdManager, "get the manager");
     dd.def_property_readonly("meta_variables", [](storm::dd::Dd<DdType> const& dd) { return dd.getContainedMetaVariables(); }, "the contained meta variables");
 
-    py::class_<storm::dd::Bdd<DdType>> bdd(m, (std::string("Bdd_") + libstring).c_str(), "Bdd", dd);
+    py::classh<storm::dd::Bdd<DdType>> bdd(m, (std::string("Bdd_") + libstring).c_str(), "Bdd", dd);
     bdd.def("to_expression", &storm::dd::Bdd<DdType>::toExpression, py::arg("expression_manager"));
 
     return dd;
 }
 
 template<storm::dd::DdType DdType, typename ValueType>
-void define_dd_typed(py::module& m, std::string const& libstring, std::string const& valueSuffix, py::class_<storm::dd::Dd<DdType>> const& dd) {
-    py::class_<storm::dd::Add<DdType, ValueType>> add(m, (std::string("Add_") + libstring + valueSuffix).c_str(), "Add", dd);
+void define_dd_typed(py::module& m, std::string const& libstring, std::string const& valueSuffix, py::classh<storm::dd::Dd<DdType>> const& dd) {
+    py::classh<storm::dd::Add<DdType, ValueType>> add(m, (std::string("Add_") + libstring + valueSuffix).c_str(), "Add", dd);
     add.def(
         "__iter__", [](const storm::dd::Add<DdType, ValueType>& s) { return py::make_iterator(s.begin(), s.end()); },
         py::keep_alive<0, 1>() /* Essential: keep object alive while iterator exists */);
 
-    py::class_<storm::dd::AddIterator<DdType, ValueType>> addIterator(m, (std::string("AddIterator_") + libstring + valueSuffix).c_str(), "AddIterator");
+    py::classh<storm::dd::AddIterator<DdType, ValueType>> addIterator(m, (std::string("AddIterator_") + libstring + valueSuffix).c_str(), "AddIterator");
     addIterator.def("get", [](const storm::dd::AddIterator<DdType, ValueType>& it) { return *it; });
 }
 
@@ -52,6 +52,6 @@ void define_dd_nt(py::module& m) {
         .finalize();
 }
 
-template py::class_<storm::dd::Dd<storm::dd::DdType::Sylvan>> define_dd<storm::dd::DdType::Sylvan>(py::module& m, std::string const& libstring);
+template py::classh<storm::dd::Dd<storm::dd::DdType::Sylvan>> define_dd<storm::dd::DdType::Sylvan>(py::module& m, std::string const& libstring);
 template void define_dd_typed<storm::dd::DdType::Sylvan, double>(py::module&, std::string const&, std::string const&,
-                                                                 py::class_<storm::dd::Dd<storm::dd::DdType::Sylvan>> const&);
+                                                                 py::classh<storm::dd::Dd<storm::dd::DdType::Sylvan>> const&);

--- a/src/storage/dd.h
+++ b/src/storage/dd.h
@@ -6,8 +6,8 @@
 #include "src/common.h"
 
 template<storm::dd::DdType DdType>
-py::class_<storm::dd::Dd<DdType>> define_dd(py::module& m, std::string const& libname);
+py::classh<storm::dd::Dd<DdType>> define_dd(py::module& m, std::string const& libname);
 template<storm::dd::DdType DdType, typename ValueType>
-void define_dd_typed(py::module& m, std::string const& libstring, std::string const& valueSuffix, py::class_<storm::dd::Dd<DdType>> const& dd);
+void define_dd_typed(py::module& m, std::string const& libstring, std::string const& valueSuffix, py::classh<storm::dd::Dd<DdType>> const& dd);
 
 void define_dd_nt(py::module& m);

--- a/src/storage/decomposition.cpp
+++ b/src/storage/decomposition.cpp
@@ -9,7 +9,7 @@ template<typename ValueType>
 using MECDecomposition = storm::storage::MaximalEndComponentDecomposition<ValueType>;
 
 void define_maximal_end_components(py::module& m) {
-    py::class_<MEC, std::shared_ptr<MEC>>(m, "MaximalEndComponent", "Maximal end component")
+    py::classh<MEC>(m, "MaximalEndComponent", "Maximal end component")
 
         .def_property_readonly("size", &MEC::size, "Number of states in MEC")
         .def(
@@ -19,8 +19,7 @@ void define_maximal_end_components(py::module& m) {
 
 template<typename ValueType>
 void define_maximal_end_component_decomposition(py::module& m, std::string const& vt_suffix) {
-    py::class_<MECDecomposition<ValueType>, std::shared_ptr<MECDecomposition<ValueType>>>(m, ("MaximalEndComponentDecomposition" + vt_suffix).c_str(),
-                                                                                          "Decomposition of maximal end components")
+    py::classh<MECDecomposition<ValueType>>(m, ("MaximalEndComponentDecomposition" + vt_suffix).c_str(), "Decomposition of maximal end components")
         .def(py::init<storm::models::sparse::NondeterministicModel<ValueType> const&>(), py::arg("model"), "Create MECs from model")
         .def_property_readonly("size", &MECDecomposition<ValueType>::size, "Number of MECs in the decomposition")
         .def(

--- a/src/storage/distribution.cpp
+++ b/src/storage/distribution.cpp
@@ -11,7 +11,7 @@ void define_distribution(py::module& m, std::string vt_suffix) {
     using Distrib = storm::storage::Distribution<ValueType, uint_fast64_t>;
 
     std::string distributionClassName = std::string("Distribution") + vt_suffix;
-    py::class_<Distrib> distribution(m, distributionClassName.c_str(), "Finite Support Distribution");
+    py::classh<Distrib> distribution(m, distributionClassName.c_str(), "Finite Support Distribution");
     distribution.def("__str__", &streamToString<Distrib>);
 }
 

--- a/src/storage/expressions.cpp
+++ b/src/storage/expressions.cpp
@@ -18,8 +18,7 @@ void define_expressions(py::module& m) {
     using Valuation = storm::expressions::Valuation;
 
     // ExpressionManager
-    py::class_<storm::expressions::ExpressionManager, std::shared_ptr<storm::expressions::ExpressionManager>>(m, "ExpressionManager",
-                                                                                                              "Manages variables for expressions")
+    py::classh<storm::expressions::ExpressionManager>(m, "ExpressionManager", "Manages variables for expressions")
         .def(py::init(), "Constructor")
         .def("create_boolean", &storm::expressions::ExpressionManager::boolean, py::arg("boolean"), "Create expression from boolean")
         .def("create_integer", &storm::expressions::ExpressionManager::integer, py::arg("integer"), "Create expression from integer number")
@@ -40,7 +39,7 @@ void define_expressions(py::module& m) {
         .def("__eq__", &storm::expressions::ExpressionManager::operator==);
 
     // Variable
-    py::class_<storm::expressions::Variable, std::shared_ptr<storm::expressions::Variable>>(m, "Variable", "Represents a variable")
+    py::classh<storm::expressions::Variable>(m, "Variable", "Represents a variable")
         .def_property_readonly("name", &storm::expressions::Variable::getName, "Variable name")
         .def_property_readonly("manager", &storm::expressions::Variable::getManager, "Variable manager")
         .def_property_readonly("index", &storm::expressions::Variable::getIndex, "Variable index")
@@ -82,7 +81,7 @@ void define_expressions(py::module& m) {
         .finalize();
 
     // Expression
-    py::class_<storm::expressions::Expression, std::shared_ptr<storm::expressions::Expression>> expression(m, "Expression", "Holds an expression");
+    py::classh<storm::expressions::Expression> expression(m, "Expression", "Holds an expression");
     expression.def(py::init<Expression>(), "other_expression"_a)
         .def("contains_variables", &storm::expressions::Expression::containsVariables, "Check if the expression contains variables.")
         .def("contains_variable", &storm::expressions::Expression::containsVariable, "Check if the expression contains any of the given variables.",
@@ -133,7 +132,7 @@ void define_expressions(py::module& m) {
         .def_static("Conjunction", [](std::vector<Expression> const& expr) { return storm::expressions::conjunction(expr); })
         .def_static("Disjunction", [](std::vector<Expression> const& expr) { return storm::expressions::disjunction(expr); });
 
-    py::class_<storm::parser::ExpressionParser>(m, "ExpressionParser", "Parser for storm-expressions")
+    py::classh<storm::parser::ExpressionParser>(m, "ExpressionParser", "Parser for storm-expressions")
         .def(py::init<storm::expressions::ExpressionManager const&>(), "Expression Manager to use", py::arg("expression_manager"))
         .def(
             "set_identifier_mapping",
@@ -143,14 +142,14 @@ void define_expressions(py::module& m) {
             "sets identifiers")
         .def("parse", &storm::parser::ExpressionParser::parseFromString, py::arg("string"), py::arg("ignore_error") = false, "parse");
 
-    py::class_<storm::expressions::Type>(m, "ExpressionType", "The type of an expression")
+    py::classh<storm::expressions::Type>(m, "ExpressionType", "The type of an expression")
         .def_property_readonly("is_boolean", &storm::expressions::Type::isBooleanType)
         .def_property_readonly("is_integer", &storm::expressions::Type::isIntegerType)
         .def_property_readonly("is_rational", &storm::expressions::Type::isRationalType)
         .def_property_readonly("is_string", &storm::expressions::Type::isStringType)
         .def("__str__", &storm::expressions::Type::getStringRepresentation);
 
-    py::class_<storm::expressions::ToDiceStringVisitor>(m, "DiceStringVisitor", "Translate expressions to dice")
+    py::classh<storm::expressions::ToDiceStringVisitor>(m, "DiceStringVisitor", "Translate expressions to dice")
         .def(py::init<uint64_t>(), py::arg("nr_bits"))
         .def("to_string", [](storm::expressions::ToDiceStringVisitor& visitor, storm::expressions::Expression const& expr) { return visitor.toString(expr); });
 }

--- a/src/storage/geometry.cpp
+++ b/src/storage/geometry.cpp
@@ -7,7 +7,7 @@
 template<typename ValueType>
 void define_geometry(py::module& m, std::string vt_suffix) {
     typedef storm::storage::geometry::Polytope<ValueType> Polytope;
-    py::class_<Polytope, std::shared_ptr<Polytope>> polytope(m, ("Polytope" + vt_suffix).c_str());
+    py::classh<Polytope> polytope(m, ("Polytope" + vt_suffix).c_str());
     polytope.def_property_readonly("vertices", &Polytope::getVertices);
     polytope.def("create_downward_closure", &Polytope::downwardClosure);
     polytope.def("get_vertices_clockwise", &Polytope::getVerticesInClockwiseOrder);

--- a/src/storage/jani.cpp
+++ b/src/storage/jani.cpp
@@ -20,7 +20,7 @@ std::string janiToString(Model const& m) {
 }
 
 void define_jani(py::module& m) {
-    py::class_<Model, std::shared_ptr<Model>> md(m, "JaniModel", "A Jani Model");
+    py::classh<Model> md(m, "JaniModel", "A Jani Model");
     md.def(py::init<Model>(), "other_model"_a)
         .def_property_readonly("name", &Model::getName, "model name")
         .def_property_readonly("model_type", &storm::jani::Model::getModelType, "Model type")
@@ -65,7 +65,7 @@ void define_jani(py::module& m) {
             return ss.str();
         });
 
-    py::class_<Automaton, std::shared_ptr<Automaton>> automaton(m, "JaniAutomaton", "A Jani Automation");
+    py::classh<Automaton> automaton(m, "JaniAutomaton", "A Jani Automation");
     automaton.def(py::init<std::string, storm::expressions::Variable>())
         .def_property_readonly(
             "edges", [](const Automaton& a) -> auto& { return a.getEdges(); }, "get edges")
@@ -84,7 +84,7 @@ void define_jani(py::module& m) {
         .def("add_edge", &Automaton::addEdge, "edge"_a)
         .def("get_location_index", &Automaton::getLocationIndex, "name"_a);
 
-    py::class_<Edge, std::shared_ptr<Edge>> edge(m, "JaniEdge", "A Jani Edge");
+    py::classh<Edge> edge(m, "JaniEdge", "A Jani Edge");
     edge.def(py::init<uint64_t, uint64_t, boost::optional<storm::expressions::Expression>, std::shared_ptr<TemplateEdge>,
                       std::vector<std::pair<uint64_t, storm::expressions::Expression>>>(),
              "source_location_index"_a, "action_index"_a, "rate"_a, "template_edge"_a, "destinations_with_probabilities"_a)
@@ -100,24 +100,24 @@ void define_jani(py::module& m) {
         .def("substitute", &Edge::substitute, py::arg("mapping"), py::arg("substitute_transcendental_numbers"))
         .def("has_silent_action", &Edge::hasSilentAction, "Is the edge labelled with the silent action");
 
-    py::class_<TemplateEdge, std::shared_ptr<TemplateEdge>> templateEdge(m, "JaniTemplateEdge", "Template edge, internal data structure for edges");
+    py::classh<TemplateEdge> templateEdge(m, "JaniTemplateEdge", "Template edge, internal data structure for edges");
     templateEdge.def(py::init<storm::expressions::Expression>())
         .def_property_readonly("assignments", [](TemplateEdge& te) -> auto& { return te.getAssignments(); })
         .def_property("guard", &TemplateEdge::getGuard, &TemplateEdge::setGuard)
         .def_property_readonly("destinations", [](TemplateEdge& te) -> auto& { return te.getDestinations(); })
         .def("add_destination", &TemplateEdge::addDestination);
 
-    py::class_<EdgeDestination, std::shared_ptr<EdgeDestination>> edgeDestination(m, "JaniEdgeDestination", "Destination in Jani");
+    py::classh<EdgeDestination> edgeDestination(m, "JaniEdgeDestination", "Destination in Jani");
     edgeDestination.def_property_readonly("target_location_index", &EdgeDestination::getLocationIndex)
         .def_property_readonly("probability", &EdgeDestination::getProbability)
         .def_property_readonly("assignments", &EdgeDestination::getOrderedAssignments);
 
-    py::class_<TemplateEdgeDestination, std::shared_ptr<TemplateEdgeDestination>> templateEdgeDestination(
-        m, "JaniTemplateEdgeDestination", "Template edge destination, internal data structure for edge destinations");
+    py::classh<TemplateEdgeDestination> templateEdgeDestination(m, "JaniTemplateEdgeDestination",
+                                                                "Template edge destination, internal data structure for edge destinations");
     templateEdgeDestination.def(py::init<OrderedAssignments>(), "ordered_assignments"_a)
         .def_property_readonly("assignments", [](TemplateEdgeDestination& ted) -> auto& { return ted.getOrderedAssignments(); });
 
-    py::class_<OrderedAssignments, std::shared_ptr<OrderedAssignments>> orderedAssignments(m, "JaniOrderedAssignments", "Set of assignments");
+    py::classh<OrderedAssignments> orderedAssignments(m, "JaniOrderedAssignments", "Set of assignments");
     orderedAssignments
         .def(
             "__iter__", [](OrderedAssignments& v) { return py::make_iterator(v.begin(), v.end()); },
@@ -131,18 +131,18 @@ void define_jani(py::module& m) {
             "add", [](OrderedAssignments& oa, Assignment const& newAssignment, bool addToExisting) { return oa.add(newAssignment, addToExisting); },
             "new_assignment"_a, "add_to_existing"_a = false);
 
-    py::class_<Assignment, std::shared_ptr<Assignment>> assignment(m, "JaniAssignment", "Jani Assignment");
+    py::classh<Assignment> assignment(m, "JaniAssignment", "Jani Assignment");
     assignment.def(py::init<Variable const&, storm::expressions::Expression const&, int64_t>(), "lhs"_a, "rhs"_a, "lvl"_a = 0)
         .def("__str__", &streamToString<Assignment>)
         .def_property("expression", &Assignment::getAssignedExpression, &Assignment::setAssignedExpression)
         .def_property_readonly("variable", &Assignment::getVariable, "variable that is assigned to, if any");
 
-    py::class_<Location, std::shared_ptr<Location>> location(m, "JaniLocation", "A Location in JANI");
+    py::classh<Location> location(m, "JaniLocation", "A Location in JANI");
     location.def(py::init<std::string const&, OrderedAssignments const&>(), "name"_a, "assignments"_a)
         .def_property_readonly("name", &Location::getName, "name of the location")
         .def_property_readonly("assignments", [](Location& loc) { loc.getAssignments(); }, "location assignments");
 
-    py::class_<VariableSet, std::shared_ptr<VariableSet>> variableSet(m, "JaniVariableSet", "Jani Set of Variables");
+    py::classh<VariableSet> variableSet(m, "JaniVariableSet", "Jani Set of Variables");
     variableSet.def(py::init<>())
         .def(
             "__iter__", [](VariableSet& v) { return py::make_iterator(v.begin(), v.end()); }, py::keep_alive<0, 1>())
@@ -155,27 +155,27 @@ void define_jani(py::module& m) {
             py::return_value_policy::reference)
         .def("erase_variable", &VariableSet::eraseVariable, "variable");
 
-    py::class_<JaniType, std::shared_ptr<JaniType>> janiType(m, "JaniType", "A Variable Type in JANI");
+    py::classh<JaniType> janiType(m, "JaniType", "A Variable Type in JANI");
     janiType.def_property_readonly("is_array_type", &JaniType::isArrayType)
         .def_property_readonly("is_bounded_type", &JaniType::isBoundedType)
         .def_property_readonly("is_clock_type", &JaniType::isClockType)
         .def_property_readonly("is_basic_type", &JaniType::isBasicType)
         .def_property_readonly("is_continuous_type", &JaniType::isContinuousType)
         .def("__str__", &JaniType::getStringRepresentation);
-    py::class_<BasicType, std::shared_ptr<BasicType>> basicType(m, "BasicType", "A basic type in JANI", janiType);
+    py::classh<BasicType> basicType(m, "BasicType", "A basic type in JANI", janiType);
     basicType.def_property_readonly("inner_type", &BasicType::get, "the inner type");
-    py::class_<BoundedType, std::shared_ptr<BoundedType>> boundedType(m, "BoundedType", "A bounded type in JANI", janiType);
+    py::classh<BoundedType> boundedType(m, "BoundedType", "A bounded type in JANI", janiType);
     boundedType.def_property_readonly("base_type", &BoundedType::getBaseType, "the base type")
         .def_property_readonly(
             "lower_bound", [](const BoundedType& tp) -> storm::expressions::Expression const& { return tp.getLowerBound(); }, "the lower bound")
         .def_property_readonly(
             "upper_bound", [](const BoundedType& tp) -> storm::expressions::Expression const& { return tp.getUpperBound(); }, "the upper bound");
-    py::class_<ClockType, std::shared_ptr<ClockType>> clockType(m, "ClockType", "A clock type in JANI", janiType);
-    py::class_<ArrayType, std::shared_ptr<ArrayType>> arrayType(m, "ArrayType", "An array type in JANI", janiType);
+    py::classh<ClockType> clockType(m, "ClockType", "A clock type in JANI", janiType);
+    py::classh<ArrayType> arrayType(m, "ArrayType", "An array type in JANI", janiType);
     arrayType.def_property_readonly("base_type", [](const ArrayType& tp) -> JaniType const& { return tp.getBaseType(); }, "the base type");
-    py::class_<ContinuousType, std::shared_ptr<ContinuousType>> continuousType(m, "ContinuousType", "A continuous type in JANI", janiType);
+    py::classh<ContinuousType> continuousType(m, "ContinuousType", "A continuous type in JANI", janiType);
 
-    py::class_<Variable, std::shared_ptr<Variable>> variable(m, "JaniVariable", "A Variable in JANI");
+    py::classh<Variable> variable(m, "JaniVariable", "A Variable in JANI");
     variable.def_property_readonly("name", &Variable::getName, "name of constant")
         .def_property_readonly(
             "type", [](Variable& v) -> JaniType const& { return v.getType(); }, "type of the variable")
@@ -183,7 +183,7 @@ void define_jani(py::module& m) {
         .def_property_readonly("init_expression", &Variable::getInitExpression)
         .def_property_readonly("is_transient", &Variable::isTransient);
 
-    py::class_<Constant, std::shared_ptr<Constant>> constant(m, "JaniConstant", "A Constant in JANI");
+    py::classh<Constant> constant(m, "JaniConstant", "A Constant in JANI");
     constant.def(py::init<std::string, storm::expressions::Variable>())
         .def_property_readonly("defined", &Constant::isDefined, "is constant defined by some expression")
         .def_property_readonly("name", &Constant::getName, "name of constant")
@@ -199,7 +199,7 @@ void define_jani(py::module& m) {
         },
         "Eliminate reward accumulations", py::arg("model"), py::arg("properties"));
 
-    py::class_<InformationObject> informationObject(m, "JaniInformationObject", "An object holding information about a JANI model");
+    py::classh<InformationObject> informationObject(m, "JaniInformationObject", "An object holding information about a JANI model");
     informationObject.def_readwrite("model_type", &InformationObject::modelType)
         .def_readwrite("nr_automata", &InformationObject::nrAutomata)
         .def_readwrite("nr_edges", &InformationObject::nrEdges)
@@ -219,11 +219,11 @@ void define_jani(py::module& m) {
 }
 
 void define_jani_transformers(py::module& m) {
-    py::class_<JaniLocationExpander>(m, "JaniLocationExpander", "A transformer for Jani expanding variables into locations")
+    py::classh<JaniLocationExpander>(m, "JaniLocationExpander", "A transformer for Jani expanding variables into locations")
         .def(py::init<Model const&>(), py::arg("model"))
         .def("transform", &JaniLocationExpander::transform, py::arg("automaton_name"), py::arg("variable_name"));
 
-    py::class_<JaniScopeChanger>(m, "JaniScopeChanger", "A transformer for Jani changing variables from local to global and vice versa")
+    py::classh<JaniScopeChanger>(m, "JaniScopeChanger", "A transformer for Jani changing variables from local to global and vice versa")
         .def(py::init<>())
         .def(
             "make_variables_local",

--- a/src/storage/labeling.cpp
+++ b/src/storage/labeling.cpp
@@ -9,7 +9,7 @@
 // Define python bindings
 void define_labeling(py::module& m) {
     // ItemLabeling
-    py::class_<storm::models::sparse::ItemLabeling, std::shared_ptr<storm::models::sparse::ItemLabeling>> labeling(m, "ItemLabeling", "Labeling");
+    py::classh<storm::models::sparse::ItemLabeling> labeling(m, "ItemLabeling", "Labeling");
     labeling.def(
                 "add_label", [](storm::models::sparse::ItemLabeling& labeling, std::string label) { labeling.addLabel(label); }, py::arg("label"), "Add label")
         .def("get_labels", &storm::models::sparse::ItemLabeling::getLabels, "Get all labels")
@@ -17,7 +17,7 @@ void define_labeling(py::module& m) {
         .def("__str__", &streamToString<storm::models::sparse::ItemLabeling>);
 
     // StateLabeling
-    py::class_<storm::models::sparse::StateLabeling, std::shared_ptr<storm::models::sparse::StateLabeling>>(m, "StateLabeling", "Labeling for states", labeling)
+    py::classh<storm::models::sparse::StateLabeling>(m, "StateLabeling", "Labeling for states", labeling)
         .def(py::init<uint_fast64_t>(), "state_count"_a)
         .def("get_labels_of_state", &storm::models::sparse::StateLabeling::getLabelsOfState, "Get labels of given state", py::arg("state"))
         .def("add_label_to_state", &storm::models::sparse::StateLabeling::addLabelToState, "Add label to state", py::arg("label"), py::arg("state"))
@@ -32,7 +32,7 @@ void define_labeling(py::module& m) {
             "Add a label to the given states", py::arg("label"), py::arg("states"))
         .def("__str__", &streamToString<storm::models::sparse::StateLabeling>);
 
-    py::class_<storm::models::sparse::ChoiceLabeling>(m, "ChoiceLabeling", "Labeling for choices", labeling)
+    py::classh<storm::models::sparse::ChoiceLabeling>(m, "ChoiceLabeling", "Labeling for choices", labeling)
         .def(py::init<uint_fast64_t>(), "choice_count"_a)
         .def("get_labels_of_choice", &storm::models::sparse::ChoiceLabeling::getLabelsOfChoice, py::arg("choice"), "Get labels of the given choice")
         .def("add_label_to_choice", &storm::models::sparse::ChoiceLabeling::addLabelToChoice, "Adds a label to a given choice", py::arg("label"),

--- a/src/storage/matrix.cpp
+++ b/src/storage/matrix.cpp
@@ -33,7 +33,7 @@ void define_sparse_matrix_nt(py::module& m) {
 template<typename ValueType>
 void define_sparse_matrix(py::module& m, std::string const& vtSuffix) {
     // MatrixEntry
-    py::class_<MatrixEntry<ValueType>>(m, (vtSuffix + "SparseMatrixEntry").c_str(), "Entry of sparse matrix")
+    py::classh<MatrixEntry<ValueType>>(m, (vtSuffix + "SparseMatrixEntry").c_str(), "Entry of sparse matrix")
         .def("__str__", &streamToString<MatrixEntry<ValueType>>)
         // def_property threw "pointer being freed not allocated" after exiting
         .def("value", &MatrixEntry<ValueType>::getValue, "Value")
@@ -41,7 +41,7 @@ void define_sparse_matrix(py::module& m, std::string const& vtSuffix) {
         .def_property_readonly("column", &MatrixEntry<ValueType>::getColumn, "Column");
 
     // SparseMatrixBuilder
-    py::class_<SparseMatrixBuilder<ValueType>>(m, (vtSuffix + "SparseMatrixBuilder").c_str(), "Builder of sparse matrix")
+    py::classh<SparseMatrixBuilder<ValueType>>(m, (vtSuffix + "SparseMatrixBuilder").c_str(), "Builder of sparse matrix")
         .def(py::init<double, double, double, bool, bool, double>(), "rows"_a = 0, "columns"_a = 0, "entries"_a = 0, "force_dimensions"_a = true,
              "has_custom_row_grouping"_a = false, "row_groups"_a = 0)
 
@@ -104,7 +104,7 @@ void define_sparse_matrix(py::module& m, std::string const& vtSuffix) {
              py::arg("replacements"), py::arg("offset"));
 
     // SparseMatrix
-    py::class_<SparseMatrix<ValueType>>(m, (vtSuffix + "SparseMatrix").c_str(), "Sparse matrix")
+    py::classh<SparseMatrix<ValueType>>(m, (vtSuffix + "SparseMatrix").c_str(), "Sparse matrix")
         .def(
             "__iter__", [](SparseMatrix<ValueType>& matrix) { return py::make_iterator(matrix.begin(), matrix.end()); },
             py::keep_alive<0, 1>() /* Essential: keep object alive while iterator exists */)
@@ -172,7 +172,7 @@ void define_sparse_matrix(py::module& m, std::string const& vtSuffix) {
             py::return_value_policy::reference, py::keep_alive<1, 0>());
 
     // Rows
-    py::class_<typename SparseMatrix<ValueType>::rows>(m, (vtSuffix + "SparseMatrixRows").c_str(), "Set of rows in a sparse matrix")
+    py::classh<typename SparseMatrix<ValueType>::rows>(m, (vtSuffix + "SparseMatrixRows").c_str(), "Set of rows in a sparse matrix")
         .def(
             "__iter__", [](typename SparseMatrix<ValueType>::rows& rows) { return py::make_iterator(rows.begin(), rows.end()); }, py::keep_alive<0, 1>())
         .def("__str__", &containerToString<typename SparseMatrix<ValueType>::rows>)

--- a/src/storage/memorystructure.cpp
+++ b/src/storage/memorystructure.cpp
@@ -8,8 +8,8 @@
 #include <storm/storage/memorystructure/SparseModelMemoryProductReverseData.h>
 
 template<typename ValueType>
-void define_memorystructure_product_each(py::class_<storm::storage::MemoryStructure, std::shared_ptr<storm::storage::MemoryStructure>>& memoryStructure,
-                                         py::class_<storm::storage::SparseModelMemoryProductReverseData>& reverseData, std::string const& vtSuffix) {
+void define_memorystructure_product_each(py::classh<storm::storage::MemoryStructure>& memoryStructure,
+                                         py::classh<storm::storage::SparseModelMemoryProductReverseData>& reverseData, std::string const& vtSuffix) {
     memoryStructure.def(
         ("_product_model" + vtSuffix).c_str(),
         [](storm::storage::MemoryStructure& ms, storm::models::sparse::Model<ValueType> const& sparseModel) { return ms.product(sparseModel); });
@@ -19,12 +19,12 @@ void define_memorystructure_product_each(py::class_<storm::storage::MemoryStruct
 
 void define_memorystructure_untyped(py::module& m) {
     typedef storm::storage::MemoryStructure MemoryStructure;
-    py::class_<MemoryStructure, std::shared_ptr<MemoryStructure>> memoryStructure(m, "MemoryStructure");
+    py::classh<MemoryStructure> memoryStructure(m, "MemoryStructure");
     memoryStructure.def("product", [](MemoryStructure& ms, MemoryStructure const& memModel) { return ms.product(memModel); });
     memoryStructure.def_property_readonly("nr_states", &MemoryStructure::getNumberOfStates);
     memoryStructure.def_property_readonly("state_labeling", &MemoryStructure::getStateLabeling);
 
-    py::class_<storm::storage::SparseModelMemoryProductReverseData> memoryProductReverseData(m, "SparseModelMemoryProductReverseData");
+    py::classh<storm::storage::SparseModelMemoryProductReverseData> memoryProductReverseData(m, "SparseModelMemoryProductReverseData");
     define_memorystructure_product_each<double>(memoryStructure, memoryProductReverseData, "_double");
     define_memorystructure_product_each<storm::RationalNumber>(memoryStructure, memoryProductReverseData, "_exact");
     define_memorystructure_product_each<storm::RationalFunction>(memoryStructure, memoryProductReverseData, "_parametric");
@@ -33,7 +33,7 @@ void define_memorystructure_untyped(py::module& m) {
 template<typename VT>
 void define_memorystructure_typed(py::module& m, std::string const& vtSuffix) {
     typedef storm::storage::MemoryStructureBuilder<VT> MemoryStructureBuilder;
-    py::class_<MemoryStructureBuilder, std::shared_ptr<MemoryStructureBuilder>> msb(m, ("MemoryStructureBuilder" + vtSuffix).c_str());
+    py::classh<MemoryStructureBuilder> msb(m, ("MemoryStructureBuilder" + vtSuffix).c_str());
     msb.def(py::init<uint_fast64_t, storm::models::sparse::Model<VT> const&, bool>(), py::arg("nr_memory_states"), py::arg("model"),
             py::arg("only_initial_states_relevant") = true);
     msb.def("build", &MemoryStructureBuilder::build);
@@ -43,7 +43,7 @@ void define_memorystructure_typed(py::module& m, std::string const& vtSuffix) {
     msb.def("set_initial_memory_state", &MemoryStructureBuilder::setInitialMemoryState, py::arg("state"), py::arg("value"));
 
     typedef storm::storage::SparseModelMemoryProduct<VT> MemoryStructureProduct;
-    py::class_<MemoryStructureProduct, std::shared_ptr<MemoryStructureProduct>> msp(m, ("MemoryStructureProduct" + vtSuffix).c_str());
+    py::classh<MemoryStructureProduct> msp(m, ("MemoryStructureProduct" + vtSuffix).c_str());
     msp.def("build", &MemoryStructureProduct::build, py::arg("preserve_model_type") = false);
     msp.def("set_build_full_product", &MemoryStructureProduct::setBuildFullProduct,
             "Enforces that every state is considered reachable and thus constructed. This causes the product to have the size of the product of the original "

--- a/src/storage/model.cpp
+++ b/src/storage/model.cpp
@@ -92,7 +92,7 @@ storm::models::sparse::StateLabeling& getLabeling(SparseModel<ValueType>& model)
 }
 
 template<typename ValueType>
-void define_model_as_sparse(py::class_<ModelBase, std::shared_ptr<ModelBase>>& modelBase) {
+void define_model_as_sparse(py::classh<ModelBase>& modelBase) {
     std::string prefix;
     if constexpr (std::is_same_v<ValueType, double>)
         prefix = "";
@@ -116,7 +116,7 @@ void define_model_as_sparse(py::class_<ModelBase, std::shared_ptr<ModelBase>>& m
 }
 
 template<typename ValueType>
-void define_model_as_symbolic(py::class_<ModelBase, std::shared_ptr<ModelBase>>& modelBase) {
+void define_model_as_symbolic(py::classh<ModelBase>& modelBase) {
     std::string prefix;
     if constexpr (std::is_same_v<ValueType, double>)
         prefix = "";
@@ -150,7 +150,7 @@ void define_model(py::module& m) {
         .finalize();
 
     // ModelBase
-    py::class_<ModelBase, std::shared_ptr<ModelBase>> modelBase(m, "_ModelBase", "Base class for all models");
+    py::classh<ModelBase> modelBase(m, "_ModelBase", "Base class for all models");
     modelBase.def_property_readonly("nr_states", &ModelBase::getNumberOfStates, "Number of states")
         .def_property_readonly("nr_transitions", &ModelBase::getNumberOfTransitions, "Number of transitions")
         .def_property_readonly("nr_choices", &ModelBase::getNumberOfChoices, "Number of choices")
@@ -176,8 +176,7 @@ void define_model(py::module& m) {
 // Bindings for sparse models
 template<typename ValueType>
 void define_sparse_model(py::module& m, std::string const& vtSuffix) {
-    py::class_<SparseModel<ValueType>, std::shared_ptr<SparseModel<ValueType>>, ModelBase> model(m, ("_Sparse" + vtSuffix + "Model").c_str(),
-                                                                                                 "A probabilistic model in a sparse matrix representation");
+    py::classh<SparseModel<ValueType>, ModelBase> model(m, ("_Sparse" + vtSuffix + "Model").c_str(), "A probabilistic model in a sparse matrix representation");
     model.def_property_readonly("supports_uncertainty", &SparseModel<ValueType>::supportsUncertainty, "Flag whether model supports uncertainty via intervals")
         .def_property_readonly("labeling", &getLabeling<ValueType>, "Labels")
         .def(
@@ -265,18 +264,15 @@ void define_sparse_model(py::module& m, std::string const& vtSuffix) {
                 },
                 py::arg("parameter"), "Find states with a particular parameter");
     }
-    py::class_<SparseDeterministicModel<ValueType>, std::shared_ptr<SparseDeterministicModel<ValueType>>> detModel(
-        m, ("_SparseDeterministic" + vtSuffix + "Model").c_str(), "Deterministic sparse model", model);
-    py::class_<SparseNondeterministicModel<ValueType>, std::shared_ptr<SparseNondeterministicModel<ValueType>>> nondetModel(
-        m, ("_SparseNondeterministic" + vtSuffix + "Model").c_str(), "Nondeterministic sparse model", model);
+    py::classh<SparseDeterministicModel<ValueType>> detModel(m, ("_SparseDeterministic" + vtSuffix + "Model").c_str(), "Deterministic sparse model", model);
+    py::classh<SparseNondeterministicModel<ValueType>> nondetModel(m, ("_SparseNondeterministic" + vtSuffix + "Model").c_str(), "Nondeterministic sparse model",
+                                                                   model);
 
-    py::class_<SparseDtmc<ValueType>, std::shared_ptr<SparseDtmc<ValueType>>>(m, ("Sparse" + vtSuffix + "Dtmc").c_str(), "DTMC in sparse representation",
-                                                                              detModel)
+    py::classh<SparseDtmc<ValueType>>(m, ("Sparse" + vtSuffix + "Dtmc").c_str(), "DTMC in sparse representation", detModel)
         .def(py::init<SparseDtmc<ValueType>>(), py::arg("other_model"))
         .def(py::init<ModelComponents<ValueType> const&>(), py::arg("components"))
         .def("__str__", &getModelInfoPrinter);
-    py::class_<SparseMdp<ValueType>, std::shared_ptr<SparseMdp<ValueType>>> mdp(m, ("Sparse" + vtSuffix + "Mdp").c_str(), "MDP in sparse representation",
-                                                                                nondetModel);
+    py::classh<SparseMdp<ValueType>> mdp(m, ("Sparse" + vtSuffix + "Mdp").c_str(), "MDP in sparse representation", nondetModel);
     mdp.def(py::init<SparseMdp<ValueType>>(), py::arg("other_model"))
         .def(py::init<ModelComponents<ValueType> const&, storm::models::ModelType>(), py::arg("components"), py::arg("type") = storm::models::ModelType::Mdp)
         .def_property_readonly("nondeterministic_choice_indices", [](SparseMdp<ValueType> const& mdp) { return mdp.getNondeterministicChoiceIndices(); })
@@ -297,8 +293,7 @@ void define_sparse_model(py::module& m, std::string const& vtSuffix) {
             },
             "apply scheduler", "scheduler"_a, "drop_unreachable_states"_a = true)
         .def("__str__", &getModelInfoPrinter);
-    py::class_<SparsePomdp<ValueType>, std::shared_ptr<SparsePomdp<ValueType>>>(m, ("Sparse" + vtSuffix + "Pomdp").c_str(), "POMDP in sparse representation",
-                                                                                mdp)
+    py::classh<SparsePomdp<ValueType>>(m, ("Sparse" + vtSuffix + "Pomdp").c_str(), "POMDP in sparse representation", mdp)
         .def(py::init<SparsePomdp<ValueType>>(), py::arg("other_model"))
         .def(py::init<ModelComponents<ValueType> const&, bool>(), py::arg("components"), py::arg("canonic_flag") = false)
         .def("__str__", &getModelInfoPrinter)
@@ -307,15 +302,13 @@ void define_sparse_model(py::module& m, std::string const& vtSuffix) {
         .def_property_readonly("nr_observations", &SparsePomdp<ValueType>::getNrObservations)
         .def("has_observation_valuations", &SparsePomdp<ValueType>::hasObservationValuations)
         .def_property_readonly("observation_valuations", &SparsePomdp<ValueType>::getObservationValuations);
-    py::class_<SparseCtmc<ValueType>, std::shared_ptr<SparseCtmc<ValueType>>>(m, ("Sparse" + vtSuffix + "Ctmc").c_str(), "CTMC in sparse representation",
-                                                                              detModel)
+    py::classh<SparseCtmc<ValueType>>(m, ("Sparse" + vtSuffix + "Ctmc").c_str(), "CTMC in sparse representation", detModel)
         .def(py::init<SparseCtmc<ValueType>>(), py::arg("other_model"))
         .def(py::init<ModelComponents<ValueType> const&>(), py::arg("components"))
         .def_property_readonly("exit_rates", [](SparseCtmc<ValueType> const& ctmc) { return ctmc.getExitRateVector(); })
         .def("probability_matrix", &SparseCtmc<ValueType>::computeProbabilityMatrix)
         .def("__str__", &getModelInfoPrinter);
-    py::class_<SparseMarkovAutomaton<ValueType>, std::shared_ptr<SparseMarkovAutomaton<ValueType>>>(m, ("Sparse" + vtSuffix + "MA").c_str(),
-                                                                                                    "MA in sparse representation", nondetModel)
+    py::classh<SparseMarkovAutomaton<ValueType>>(m, ("Sparse" + vtSuffix + "MA").c_str(), "MA in sparse representation", nondetModel)
         .def(py::init<SparseMarkovAutomaton<ValueType>>(), py::arg("other_model"))
         .def(py::init<ModelComponents<ValueType> const&>(), py::arg("components"))
         .def_property_readonly("exit_rates", [](SparseMarkovAutomaton<ValueType> const& ma) { return ma.getExitRates(); })
@@ -336,14 +329,13 @@ void define_sparse_model(py::module& m, std::string const& vtSuffix) {
                                "Check whether the MA can be converted into a CTMC.")
         .def("convert_to_ctmc", &SparseMarkovAutomaton<ValueType>::convertToCtmc, "Convert the MA into a CTMC.");
 
-    py::class_<SparseSmg<ValueType>, std::shared_ptr<SparseSmg<ValueType>>>(m, ("Sparse" + vtSuffix + "Smg").c_str(), "SMG in sparse representation",
-                                                                            nondetModel)
+    py::classh<SparseSmg<ValueType>>(m, ("Sparse" + vtSuffix + "Smg").c_str(), "SMG in sparse representation", nondetModel)
         .def(py::init<SparseSmg<ValueType>>(), py::arg("other_model"))
         .def(py::init<ModelComponents<ValueType> const&>(), py::arg("components"))
         .def("get_state_player_indications", &SparseSmg<ValueType>::getStatePlayerIndications, "Get for each state its corresponding player")
         .def("get_player_of_state", &SparseSmg<ValueType>::getPlayerOfState, py::arg("state"), "Get player for the given state");
 
-    py::class_<SparseRewardModel<ValueType>>(m, ("Sparse" + vtSuffix + "RewardModel").c_str(), "Reward structure for sparse models")
+    py::classh<SparseRewardModel<ValueType>>(m, ("Sparse" + vtSuffix + "RewardModel").c_str(), "Reward structure for sparse models")
         .def(py::init<std::optional<std::vector<ValueType>> const&, std::optional<std::vector<ValueType>> const&,
                       std::optional<storm::storage::SparseMatrix<ValueType>> const&>(),
              py::arg("optional_state_reward_vector") = std::nullopt, py::arg("optional_state_action_reward_vector") = std::nullopt,
@@ -372,8 +364,8 @@ void define_sparse_model(py::module& m, std::string const& vtSuffix) {
 // Bindings for symbolic models
 template<storm::dd::DdType DdType, typename ValueType>
 void define_symbolic_model(py::module& m, std::string vt_suffix) {
-    py::class_<SymbolicModel<DdType, ValueType>, std::shared_ptr<SymbolicModel<DdType, ValueType>>, ModelBase> model(
-        m, ("_Symbolic" + vt_suffix + "Model").c_str(), "A probabilistic model in a symbolic representation");
+    py::classh<SymbolicModel<DdType, ValueType>, ModelBase> model(m, ("_Symbolic" + vt_suffix + "Model").c_str(),
+                                                                  "A probabilistic model in a symbolic representation");
     model.def_property_readonly(
              "reward_models", [](SymbolicModel<DdType, ValueType>& model) { return model.getRewardModels(); }, "Reward models")
         .def_property_readonly("dd_manager", &SymbolicModel<DdType, ValueType>::getManager, "dd manager")
@@ -395,20 +387,16 @@ void define_symbolic_model(py::module& m, std::string vt_suffix) {
     if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) {
         model.def("get_parameters", &SymbolicModel<DdType, ValueType>::getParameters, "Get parameters");
     }
-    py::class_<SymbolicDtmc<DdType, ValueType>, std::shared_ptr<SymbolicDtmc<DdType, ValueType>>>(m, ("Symbolic" + vt_suffix + "Dtmc").c_str(),
-                                                                                                  "DTMC in symbolic representation", model)
+    py::classh<SymbolicDtmc<DdType, ValueType>>(m, ("Symbolic" + vt_suffix + "Dtmc").c_str(), "DTMC in symbolic representation", model)
         .def("__str__", &getModelInfoPrinter);
-    py::class_<SymbolicMdp<DdType, ValueType>, std::shared_ptr<SymbolicMdp<DdType, ValueType>>>(m, ("Symbolic" + vt_suffix + "Mdp").c_str(),
-                                                                                                "MDP in symbolic representation", model)
+    py::classh<SymbolicMdp<DdType, ValueType>>(m, ("Symbolic" + vt_suffix + "Mdp").c_str(), "MDP in symbolic representation", model)
         .def("__str__", &getModelInfoPrinter);
-    py::class_<SymbolicCtmc<DdType, ValueType>, std::shared_ptr<SymbolicCtmc<DdType, ValueType>>>(m, ("Symbolic" + vt_suffix + "Ctmc").c_str(),
-                                                                                                  "CTMC in symbolic representation", model)
+    py::classh<SymbolicCtmc<DdType, ValueType>>(m, ("Symbolic" + vt_suffix + "Ctmc").c_str(), "CTMC in symbolic representation", model)
         .def("__str__", &getModelInfoPrinter);
-    py::class_<SymbolicMarkovAutomaton<DdType, ValueType>, std::shared_ptr<SymbolicMarkovAutomaton<DdType, ValueType>>>(
-        m, ("Symbolic" + vt_suffix + "MA").c_str(), "MA in symbolic representation", model)
+    py::classh<SymbolicMarkovAutomaton<DdType, ValueType>>(m, ("Symbolic" + vt_suffix + "MA").c_str(), "MA in symbolic representation", model)
         .def("__str__", &getModelInfoPrinter);
 
-    py::class_<SymbolicRewardModel<DdType, ValueType>>(m, ("Symbolic" + vt_suffix + "RewardModel").c_str(), "Reward structure for symbolic models")
+    py::classh<SymbolicRewardModel<DdType, ValueType>>(m, ("Symbolic" + vt_suffix + "RewardModel").c_str(), "Reward structure for symbolic models")
         .def_property_readonly("has_state_rewards", &SymbolicRewardModel<DdType, ValueType>::hasStateRewards)
         .def_property_readonly("has_state_action_rewards", &SymbolicRewardModel<DdType, ValueType>::hasStateActionRewards)
         .def_property_readonly("has_transition_rewards", &SymbolicRewardModel<DdType, ValueType>::hasTransitionRewards);

--- a/src/storage/model_components.cpp
+++ b/src/storage/model_components.cpp
@@ -21,8 +21,7 @@ using SparseModelComponents = storm::storage::sparse::ModelComponents<ValueType>
 
 template<typename ValueType>
 void define_sparse_model_components(py::module& m, std::string const& vtSuffix) {
-    py::class_<SparseModelComponents<ValueType>, std::shared_ptr<SparseModelComponents<ValueType>>>(m, ("Sparse" + vtSuffix + "ModelComponents").c_str(),
-                                                                                                    "Components required for building a sparse model")
+    py::classh<SparseModelComponents<ValueType>>(m, ("Sparse" + vtSuffix + "ModelComponents").c_str(), "Components required for building a sparse model")
 
         .def(py::init<SparseMatrix<ValueType> const&, StateLabeling const&, std::unordered_map<std::string, SparseRewardModel<ValueType>> const&, bool,
                       boost::optional<BitVector> const&, boost::optional<SparseMatrix<storm::storage::sparse::state_type>> const&>(),

--- a/src/storage/prism.cpp
+++ b/src/storage/prism.cpp
@@ -31,7 +31,7 @@ template<typename StateType, typename ValueType>
 void define_stateGeneration(py::module& m);
 
 void define_prism(py::module& m) {
-    py::class_<storm::prism::Program, std::shared_ptr<storm::prism::Program>> program(m, "PrismProgram", "A Prism Program");
+    py::classh<storm::prism::Program> program(m, "PrismProgram", "A Prism Program");
     program.def_property_readonly("constants", &Program::getConstants, "Get Program Constants")
         .def_property_readonly("global_boolean_variables", &Program::getGlobalBooleanVariables, "Retrieves the global boolean variables of the program")
         .def_property_readonly("global_integer_variables", &Program::getGlobalIntegerVariables, "Retrieves the global integer variables of the program")
@@ -97,7 +97,7 @@ void define_prism(py::module& m) {
             "Get the expression of the given label.", py::arg("label"))
         .def_property_readonly("labels", &Program::getLabels, "Get all labels in the program");
 
-    py::class_<Module> module(m, "PrismModule", "A module in a Prism program");
+    py::classh<Module> module(m, "PrismModule", "A module in a Prism program");
     module.def_property_readonly(
               "commands", [](Module const& module) { return module.getCommands(); }, "Commands in the module")
         .def_property_readonly("name", &Module::getName, "Name of the module")
@@ -108,7 +108,7 @@ void define_prism(py::module& m) {
         .def("get_command_indices_by_action_index", &Module::getCommandIndicesByActionIndex, py::arg("action_index"))
         .def("__str__", &streamToString<Module>);
 
-    py::class_<Command> command(m, "PrismCommand", "A command in a Prism program");
+    py::classh<Command> command(m, "PrismCommand", "A command in a Prism program");
     command.def_property_readonly("global_index", &Command::getGlobalIndex, "Get global index")
         .def_property_readonly("labeled", &Command::isLabeled, "Is the command labeled")
         .def_property_readonly("action_index", &Command::getActionIndex, "What is the action index of the command")
@@ -119,7 +119,7 @@ void define_prism(py::module& m) {
             "updates", [](Command const& command) { return command.getUpdates(); }, "Updates in the command")
         .def("__str__", &streamToString<Command>);
 
-    py::class_<Update> update(m, "PrismUpdate", "An update in a Prism command");
+    py::classh<Update> update(m, "PrismUpdate", "An update in a Prism command");
     update.def(py::init<uint_fast64_t, storm::expressions::Expression const&, std::vector<storm::prism::Assignment> const&>())
         .def_property_readonly(
             "assignments", [](Update const& update) { return update.getAssignments(); }, "Assignments in the update")
@@ -131,13 +131,13 @@ void define_prism(py::module& m) {
         .def("get_as_variable_to_expression_map", &Update::getAsVariableToExpressionMap, "Creates a mapping representation of this update")
         .def("__str__", &streamToString<Update>);
 
-    py::class_<Assignment> assignment(m, "PrismAssignment", "An assignment in prism");
+    py::classh<Assignment> assignment(m, "PrismAssignment", "An assignment in prism");
     assignment.def(py::init<storm::expressions::Variable const&, storm::expressions::Expression const&>())
         .def_property_readonly("variable", &Assignment::getVariable, "Variable that is updated")
         .def_property_readonly("expression", &Assignment::getExpression, "Expression for the update")
         .def("__str__", &streamToString<Assignment>);
 
-    py::class_<Label> label(m, "PrismLabel", "A label in prism");
+    py::classh<Label> label(m, "PrismLabel", "A label in prism");
     label.def_property_readonly("name", &Label::getName);
     label.def_property_readonly("expression", &Label::getStatePredicateExpression);
 
@@ -152,35 +152,33 @@ void define_prism(py::module& m) {
         .value("UNDEFINED", storm::prism::Program::ModelType::UNDEFINED)
         .finalize();
 
-    py::class_<Constant, std::shared_ptr<Constant>> constant(m, "PrismConstant", "A constant in a Prism program");
+    py::classh<Constant> constant(m, "PrismConstant", "A constant in a Prism program");
     constant.def_property_readonly("name", &Constant::getName, "Constant name")
         .def_property_readonly("defined", &Constant::isDefined, "Is the constant defined?")
         .def_property_readonly("type", &Constant::getType, "The type of the constant")
         .def_property_readonly("expression_variable", &Constant::getExpressionVariable, "Expression variable")
         .def_property_readonly("definition", &Constant::getExpression, "Defining expression");
 
-    py::class_<Variable, std::shared_ptr<Variable>> variable(m, "PrismVariable", "A program variable in a Prism program");
+    py::classh<Variable> variable(m, "PrismVariable", "A program variable in a Prism program");
     variable.def_property_readonly("name", &Variable::getName, "Variable name")
         .def_property_readonly("initial_value_expression", &Variable::getInitialValueExpression, "The expression represented the initial value of the variable")
         .def_property_readonly("expression_variable", &Variable::getExpressionVariable, "The expression variable corresponding to the variable");
 
-    py::class_<IntegerVariable, std::shared_ptr<IntegerVariable>> integer_variable(m, "PrismIntegerVariable", variable,
-                                                                                   "A program integer variable in a Prism program");
+    py::classh<IntegerVariable> integer_variable(m, "PrismIntegerVariable", variable, "A program integer variable in a Prism program");
     integer_variable
         .def_property_readonly("lower_bound_expression", &IntegerVariable::getLowerBoundExpression, "The the lower bound expression of this integer variable")
         .def_property_readonly("upper_bound_expression", &IntegerVariable::getUpperBoundExpression, "The the upper bound expression of this integer variable")
         .def("__str__", &streamToString<IntegerVariable>);
 
-    py::class_<BooleanVariable, std::shared_ptr<BooleanVariable>> boolean_variable(m, "PrismBooleanVariable", variable,
-                                                                                   "A program boolean variable in a Prism program");
+    py::classh<BooleanVariable> boolean_variable(m, "PrismBooleanVariable", variable, "A program boolean variable in a Prism program");
     boolean_variable.def("__str__", &streamToString<BooleanVariable>);
 
-    py::class_<RewardModel, std::shared_ptr<RewardModel>> rewardModel(m, "PrismRewardModel", "Reward declaration in prism");
+    py::classh<RewardModel> rewardModel(m, "PrismRewardModel", "Reward declaration in prism");
     rewardModel.def_property_readonly("name", &RewardModel::getName, "get name of the reward model");
 
     // define_stateGeneration<uint32_t, storm::RationalNumber>(m);
 
-    py::class_<OverlappingGuardAnalyser> oga(m, "OverlappingGuardAnalyser", "An SMT driven analysis for overlapping guards");
+    py::classh<OverlappingGuardAnalyser> oga(m, "OverlappingGuardAnalyser", "An SMT driven analysis for overlapping guards");
     oga.def(py::init<Program const&, std::shared_ptr<storm::utility::solver::SmtSolverFactory>&>(), py::arg("program"), py::arg("smt solver factory"));
     oga.def("has_module_with_inner_action_overlapping_guard", &OverlappingGuardAnalyser::hasModuleWithInnerActionOverlap);
 }

--- a/src/storage/scheduler.cpp
+++ b/src/storage/scheduler.cpp
@@ -12,7 +12,7 @@ void define_scheduler(py::module& m, std::string vt_suffix) {
     using SchedulerChoice = storm::storage::SchedulerChoice<ValueType>;
 
     std::string schedulerClassName = std::string("Scheduler") + vt_suffix;
-    py::class_<Scheduler, std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler(m, schedulerClassName.c_str(), "A Finite Memory Scheduler");
+    py::classh<Scheduler> scheduler(m, schedulerClassName.c_str(), "A Finite Memory Scheduler");
     scheduler
         .def("__str__",
              [](Scheduler const& s) {
@@ -61,7 +61,7 @@ void define_scheduler(py::module& m, std::string vt_suffix) {
     }
 
     std::string schedulerChoiceClassName = std::string("SchedulerChoice") + vt_suffix;
-    py::class_<SchedulerChoice> schedulerChoice(m, schedulerChoiceClassName.c_str(), "A choice of a finite memory scheduler");
+    py::classh<SchedulerChoice> schedulerChoice(m, schedulerChoiceClassName.c_str(), "A choice of a finite memory scheduler");
     schedulerChoice.def(py::init<uint64_t>(), "choice"_a)
         .def_property_readonly("defined", &SchedulerChoice::isDefined, "Is the choice defined by the scheduler?")
         .def_property_readonly("deterministic", &SchedulerChoice::isDeterministic, "Is the choice deterministic (given by a Dirac distribution)?")

--- a/src/storage/state.cpp
+++ b/src/storage/state.cpp
@@ -5,12 +5,12 @@
 template<typename ValueType>
 void define_state(py::module& m, std::string const& vtSuffix) {
     // SparseModelStates
-    py::class_<SparseModelStates<ValueType>>(m, ("Sparse" + vtSuffix + "ModelStates").c_str(), "States in sparse model")
+    py::classh<SparseModelStates<ValueType>>(m, ("Sparse" + vtSuffix + "ModelStates").c_str(), "States in sparse model")
         .def("__getitem__", &SparseModelStates<ValueType>::getState)
         .def("__len__", &SparseModelStates<ValueType>::getSize);
 
     // SparseModelState
-    py::class_<SparseModelState<ValueType>>(m, ("Sparse" + vtSuffix + "ModelState").c_str(), "State in sparse model")
+    py::classh<SparseModelState<ValueType>>(m, ("Sparse" + vtSuffix + "ModelState").c_str(), "State in sparse model")
         .def("__str__", &SparseModelState<ValueType>::toString)
         .def_property_readonly("id", &SparseModelState<ValueType>::getIndex, "Id")
         .def_property_readonly("labels", &SparseModelState<ValueType>::getLabels, "Get state labels")
@@ -19,12 +19,12 @@ void define_state(py::module& m, std::string const& vtSuffix) {
         .def("__int__", &SparseModelState<ValueType>::getIndex);
 
     // SparseModelActions
-    py::class_<SparseModelActions<ValueType>>(m, ("Sparse" + vtSuffix + "ModelActions").c_str(), "Actions for state in sparse model")
+    py::classh<SparseModelActions<ValueType>>(m, ("Sparse" + vtSuffix + "ModelActions").c_str(), "Actions for state in sparse model")
         .def("__getitem__", &SparseModelActions<ValueType>::getAction)
         .def("__len__", &SparseModelActions<ValueType>::getSize);
 
     // SparseModelAction
-    py::class_<SparseModelAction<ValueType>>(m, ("Sparse" + vtSuffix + "ModelAction").c_str(), "Action for state in sparse model")
+    py::classh<SparseModelAction<ValueType>>(m, ("Sparse" + vtSuffix + "ModelAction").c_str(), "Action for state in sparse model")
         .def("__str__", &SparseModelAction<ValueType>::toString)
         .def_property_readonly("id", &SparseModelAction<ValueType>::getIndex, "Id")
         .def_property_readonly("transitions", &SparseModelAction<ValueType>::getTransitions, "Get transitions")

--- a/src/storage/umb.cpp
+++ b/src/storage/umb.cpp
@@ -28,7 +28,7 @@ void define_umb(py::module& m) {
         .value("Double", storm::umb::ImportOptions::ValueType::Double)
         .finalize();
 
-    py::class_<storm::umb::ImportOptions>(m, "UmbImportOptions", "Options for importing UMB models")
+    py::classh<storm::umb::ImportOptions>(m, "UmbImportOptions", "Options for importing UMB models")
         .def(py::init<>())
         .def_readwrite("value_type", &storm::umb::ImportOptions::valueType, "Value type used for all model values")
         .def_readwrite("build_choice_labeling", &storm::umb::ImportOptions::buildChoiceLabeling, "Whether to build choice labelings")
@@ -42,7 +42,7 @@ void define_umb(py::module& m) {
         .value("RationalInterval", storm::umb::ExportOptions::ValueType::RationalInterval)
         .finalize();
 
-    py::class_<storm::umb::ExportOptions>(m, "UmbExportOptions", "Options for exporting UMB models")
+    py::classh<storm::umb::ExportOptions>(m, "UmbExportOptions", "Options for exporting UMB models")
         .def(py::init<>())
         .def_readwrite("value_type", &storm::umb::ExportOptions::valueType, "Value type used for all model values")
         .def_readwrite("allow_choice_origins_as_actions", &storm::umb::ExportOptions::allowChoiceOriginsAsActions,
@@ -52,7 +52,7 @@ void define_umb(py::module& m) {
         .def_readwrite("compression", &storm::umb::ExportOptions::compression, "Compression mode for the UMB archive")
         .def_readwrite("canonicize_pomdp", &storm::umb::ExportOptions::canonicizePomdp, "Whether to canonicize POMDPs before export");
 
-    py::class_<storm::umb::UmbModel>(m, "UmbModel", "Model in the UMB format")
+    py::classh<storm::umb::UmbModel>(m, "UmbModel", "Model in the UMB format")
         .def("get_short_model_information", &storm::umb::UmbModel::getShortModelInformation, "Short description of the model")
         .def("get_model_information", &storm::umb::UmbModel::getModelInformation, "Detailed description of the model")
         .def(

--- a/src/storage/valuation.cpp
+++ b/src/storage/valuation.cpp
@@ -33,9 +33,9 @@ std::vector<bool> booleanValuesAsVector(Valuations const& v, storm::expressions:
 
 void define_valuation(py::module& m) {
     // Opaque description type — constructed via ValuationDescriptionBuilder, passed to Valuations constructor
-    py::class_<ValuationClassDescription>(m, "ValuationClassDescription", "Schema describing the variables of a valuation class");
+    py::classh<ValuationClassDescription>(m, "ValuationClassDescription", "Schema describing the variables of a valuation class");
 
-    py::class_<ValuationDescriptionBuilder>(m, "ValuationDescriptionBuilder", "Incrementally builds a ValuationClassDescription")
+    py::classh<ValuationDescriptionBuilder>(m, "ValuationDescriptionBuilder", "Incrementally builds a ValuationClassDescription")
         .def(py::init([](storm::expressions::ExpressionManager& manager) { return ValuationDescriptionBuilder(manager.getSharedPointer()); }),
              py::arg("manager"), py::keep_alive<1, 2>())
         .def("add_boolean_variable", &ValuationDescriptionBuilder::addBooleanVariable, py::arg("variable"), py::arg("optional") = false,
@@ -55,7 +55,7 @@ void define_valuation(py::module& m) {
         .def("add_string_variable", &ValuationDescriptionBuilder::addStringVariable, py::arg("variable"), py::arg("optional") = false, "Add a string variable")
         .def("build_class_description", &ValuationDescriptionBuilder::buildClassDescription, "Finalise and return the class description");
 
-    py::class_<Valuations, std::shared_ptr<Valuations>>(m, "Valuations", "Valuations for explicit entities (states/observations)")
+    py::classh<Valuations>(m, "Valuations", "Valuations for explicit entities (states/observations)")
         .def(py::init([](ValuationClassDescription const& desc, storm::expressions::ExpressionManager& manager, uint64_t numEntities) {
                  return std::make_shared<Valuations>(desc, manager.getSharedPointer(), numEntities);
              }),
@@ -245,7 +245,7 @@ void define_valuation(py::module& m) {
 }
 
 void define_valuation_transformer(py::module& m) {
-    py::class_<storm::storage::sparse::ValuationTransformer>(
+    py::classh<storm::storage::sparse::ValuationTransformer>(
         m, "ValuationTransformer",
         "Transforms the given valuations to a new valuations over a new variable set. The values of the new variables are determined by evaluating "
         "the provided expressions w.r.t. the old variable valuation. The freshly introduced variables may either replace or extend the existing variable set.")
@@ -255,10 +255,10 @@ void define_valuation_transformer(py::module& m) {
 }
 
 void define_simplevaluation(py::module& m) {
-    py::class_<storm::expressions::Valuation> val(m, "Valuation");
+    py::classh<storm::expressions::Valuation> val(m, "Valuation");
     val.def_property_readonly("expression_manager", &storm::expressions::Valuation::getManager);
 
-    py::class_<storm::expressions::SimpleValuation>(m, "SimpleValuation", val)
+    py::classh<storm::expressions::SimpleValuation>(m, "SimpleValuation", val)
         .def("to_json", &storm::expressions::SimpleValuation::toJson, "Convert to JSON")
         .def("to_string", &storm::expressions::SimpleValuation::toString, py::arg("pretty") = true, "to string")
         .def("_get_boolean_value", &storm::expressions::SimpleValuation::getBooleanValue, py::arg("variable"), "Get Boolean value for expression variable")

--- a/src/utility/chrono.cpp
+++ b/src/utility/chrono.cpp
@@ -5,7 +5,7 @@
 #include "src/helpers.h"
 
 void define_chrono(py::module& m) {
-    py::class_<std::chrono::milliseconds>(m, "milliseconds")
+    py::classh<std::chrono::milliseconds>(m, "milliseconds")
         .def("count", &std::chrono::milliseconds::count)
         .def("__str__", [](std::chrono::milliseconds const& t) {
             std::stringstream strstr;

--- a/src/utility/json.cpp
+++ b/src/utility/json.cpp
@@ -6,7 +6,7 @@
 
 template<typename RationalValueType>
 void define_json(py::module& m, std::string const& vtSuffix) {
-    py::class_<storm::json<RationalValueType>> jsoncont(m, ("JsonContainer" + vtSuffix).c_str(), "Storm-internal container for JSON structures");
+    py::classh<storm::json<RationalValueType>> jsoncont(m, ("JsonContainer" + vtSuffix).c_str(), "Storm-internal container for JSON structures");
     jsoncont.def("__str__", [](storm::json<RationalValueType> const& container) { return container.dump(4); });
     jsoncont.def("__getitem__", [](storm::json<RationalValueType> const& container, std::string const& item) { return container[item]; });
 }

--- a/src/utility/shortestPaths.cpp
+++ b/src/utility/shortestPaths.cpp
@@ -24,7 +24,7 @@ void define_ksp(py::module& m) {
     using Model = ShortestPathsGenerator::Model;
     using StateProbMap = ShortestPathsGenerator::StateProbMap;
 
-    py::class_<Path>(m, "Path")
+    py::classh<Path>(m, "Path")
         // overload constructor rather than dealing with boost::optional
         .def(py::init([](state_t preNode, unsigned long preK, double distance) { return Path{boost::optional<state_t>(preNode), preK, distance}; }),
              "predecessorNode"_a, "predecessorK"_a, "distance"_a)
@@ -44,7 +44,7 @@ void define_ksp(py::module& m) {
         .value("I_Minus_P", MatrixFormat::iMinusP)
         .finalize();
 
-    py::class_<ShortestPathsGenerator>(m, "ShortestPathsGenerator")
+    py::classh<ShortestPathsGenerator>(m, "ShortestPathsGenerator")
         .def(py::init<Model const&, BitVector>(), "model"_a, "target_bitvector"_a)
         .def(py::init<Model const&, state_t>(), "model"_a, "target_state"_a)
         .def(py::init<Model const&, std::vector<state_t> const&>(), "model"_a, "target_state_list"_a)

--- a/src/utility/smtsolver.cpp
+++ b/src/utility/smtsolver.cpp
@@ -16,12 +16,12 @@ void define_smt(py::module& m) {
         .value("Unknown", SmtSolver::CheckResult::Unknown)
         .finalize();
 
-    py::class_<ModelReference, std::shared_ptr<ModelReference>> modelref(m, "ModelReference", "Lightweight Wrapper around results");
+    py::classh<ModelReference> modelref(m, "ModelReference", "Lightweight Wrapper around results");
     modelref.def("get_boolean_value", &ModelReference::getBooleanValue, "get a value for a boolean variable", py::arg("variable"))
         .def("get_integer_value", &ModelReference::getIntegerValue, "get a value for an integer variable", py::arg("variable"))
         .def("get_rational_value", &ModelReference::getRationalValue, "get a value (as double) for an rational variable", py::arg("variable"));
 
-    py::class_<SmtSolver> smtsolver(m, "SmtSolver", "Generic Storm SmtSolver Wrapper");
+    py::classh<SmtSolver> smtsolver(m, "SmtSolver", "Generic Storm SmtSolver Wrapper");
     smtsolver.def("push", &SmtSolver::push, "push")
         .def(
             "pop", [](SmtSolver& solver, uint64_t n) { solver.pop(n); }, "pop", py::arg("levels"))
@@ -31,12 +31,10 @@ void define_smt(py::module& m) {
         .def("check", &SmtSolver::check, "check")
         .def_property_readonly("model", &SmtSolver::getModel, "get the model");
 
-    py::class_<Z3SmtSolver> z3solver(m, "Z3SmtSolver", "z3 API for storm smtsolver wrapper", smtsolver);
+    py::classh<Z3SmtSolver> z3solver(m, "Z3SmtSolver", "z3 API for storm smtsolver wrapper", smtsolver);
     z3solver.def(pybind11::init<storm::expressions::ExpressionManager&>());
 
-    py::class_<storm::utility::solver::SmtSolverFactory, std::shared_ptr<storm::utility::solver::SmtSolverFactory>> smtfactory(
-        m, "SmtSolverFactory", "Factory for creating SMT Solvers");
-    py::class_<storm::utility::solver::Z3SmtSolverFactory, std::shared_ptr<storm::utility::solver::Z3SmtSolverFactory>> z3factory(
-        m, "Z3SmtSolverFactory", "Factory for creating z3 based SMT solvers", smtfactory);
+    py::classh<storm::utility::solver::SmtSolverFactory> smtfactory(m, "SmtSolverFactory", "Factory for creating SMT Solvers");
+    py::classh<storm::utility::solver::Z3SmtSolverFactory> z3factory(m, "Z3SmtSolverFactory", "Factory for creating z3 based SMT solvers", smtfactory);
     z3factory.def(py::init<>());
 }


### PR DESCRIPTION
Fixes #303. I ran this script on the source code:

```
#!/usr/bin/env python3
import re
from pathlib import Path


def split_args(s):
    parts, start, depth = [], 0, 0
    for i, c in enumerate(s):
        depth += c in "<([{"
        depth -= c in ">)]}"
        if c == "," and depth == 0:
            parts.append(s[start:i])
            start = i + 1
    return parts + [s[start:]]


for path in Path("src").rglob("*"):
    if path.suffix not in {".cpp", ".h"}:
        continue
    text, pos = path.read_text(), 0
    while (start := text.find("py::class_<", pos)) >= 0:
        if text[text.rfind("\n", 0, start) + 1 : start].lstrip().startswith("//"):
            pos = start + 1
            continue
        end, depth = start + len("py::class_"), 0
        while end < len(text):
            depth += text[end] == "<"
            depth -= text[end] == ">"
            if depth == 0:
                break
            end += 1
        args = split_args(text[start + len("py::class_<") : end])
        args = [a for a in args if not re.fullmatch(r"\s*std::(?:shared|unique)_ptr<.*>\s*", a, re.S)]
        replacement = "py::classh<" + ",".join(args) + ">"
        text = text[:start] + replacement + text[end + 1 :]
        pos = start + len(replacement)
    text = re.sub(r"(?m)^PYBIND11_DECLARE_HOLDER_TYPE\(T, std::shared_ptr<T(?: const)?>\)\n\n?", "", text)
    path.write_text(text)
```